### PR TITLE
Every dataset now knows its prefix, because it's always stored with the ...

### DIFF
--- a/app/assets/javascripts/dashboard/dashboard-controllers.js
+++ b/app/assets/javascripts/dashboard/dashboard-controllers.js
@@ -105,7 +105,7 @@ define(["angular"], function () {
             }
             file.uploading = true;
             $upload.upload({
-                url: '/narthex/dashboard/' + file.name + '/upload',
+                url: '/narthex/dashboard/' + file.name + '/upload/' + file.prefix,
                 file: onlyFile
             }).progress(
                 function (evt) {
@@ -200,6 +200,7 @@ define(["angular"], function () {
             }
             if (info.origin) {
                 file.origin = info.origin.type;
+                file.prefix = info.origin.prefix;
             }
             if (info.delimit && info.delimit.recordCount > 0) {
                 file.identity.recordCount = info.delimit.recordCount;
@@ -211,33 +212,23 @@ define(["angular"], function () {
             if (info.tree) {
                 file.treeTime = info.tree.time;
             }
-            if (info.records) {
-                file.recordsTime = info.records.time;
-            }
             if (!info.publication) info.publication = {};
             if (!info.categories) info.categories = {};
-
             function oaiPmhListRecords(enriched) {
                 var absUrl = $location.absUrl();
                 var serverUrl = absUrl.substring(0, absUrl.indexOf("#"));
                 var start = enriched ? 'oai-pmh/enriched/' : 'oai-pmh/';
-                var parts = info.publication.oaipmhPrefixes.split(/[\s.;,]+/);
-                return _.map(parts, function(prefix) {
-                    return {
-                        prefix: prefix,
-                        url: serverUrl + start + API_ACCESS_KEY + '?verb=ListRecords&set=' + file.name + "&metadataPrefix=" + prefix
-                    }
-                });
+                return {
+                    prefix: file.prefix,
+                    url: serverUrl + start + API_ACCESS_KEY + '?verb=ListRecords&set=' + file.name + "&metadataPrefix=" + file.prefix
+                }
             }
-
-            if (info.publication.oaipmhPrefixes && info.publication.oaipmhPrefixes.length) {
-                file.oaiPmhListRecords = oaiPmhListRecords(false);
-                file.oaiPmhListEnrichedRecords = oaiPmhListRecords(true);
-            }
-            else if (info.publication.oaipmh == "true") {
-                info.publication.oaipmhPrefixes = "verbatim";
-                file.oaiPmhListRecords = oaiPmhListRecords(false);
-                file.oaiPmhListEnrichedRecords = oaiPmhListRecords(true);
+            if (info.records) {
+                file.recordsTime = info.records.time;
+                if (file.prefix) {
+                    file.oaiPmhListRecords = oaiPmhListRecords(false);
+                    file.oaiPmhListEnrichedRecords = oaiPmhListRecords(true);
+                }
             }
         }
 

--- a/app/harvest/Harvesting.scala
+++ b/app/harvest/Harvesting.scala
@@ -21,7 +21,6 @@ import play.api.Logger
 import play.api.Play.current
 import play.api.libs.ws.WS
 import services.NarthexConfig
-import services.StringHandling.VERBATIM
 import services.Temporal._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -265,14 +264,14 @@ trait Harvesting {
       }
       error getOrElse {
         val tokenNode = response.xml \ "ListRecords" \ "resumptionToken"
-        val newToken = if (tokenNode.nonEmpty && tokenNode.text.trim.nonEmpty) {
+        val newToken = if (tokenNode.text.trim.nonEmpty) {
           val completeListSize = tagToInt(tokenNode, "@completeListSize")
           val cursor = tagToInt(tokenNode, "@cursor", 1)
           Some(PMHResumptionToken(
             value = tokenNode.text,
             currentRecord = cursor,
             totalRecords = completeListSize,
-            prefix = VERBATIM
+            prefix = metadataPrefix
           ))
         }
         else {

--- a/app/harvest/OaiPmh.scala
+++ b/app/harvest/OaiPmh.scala
@@ -18,7 +18,7 @@ package harvest
 
 import harvest.Harvesting.{Harvest, PMHResumptionToken, PublishedDataset, RepoMetadataFormat}
 import harvest.OaiPmh.Service.{QueryKey, Verb}
-import org.OrgRepo
+import org.OrgRepo.repo
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.Play.current
@@ -60,11 +60,11 @@ object OaiPmh extends Controller {
     val pageSize = NarthexConfig.OAI_PMH_PAGE_SIZE
 
     def getFormats(identifier: Option[String]): Seq[RepoMetadataFormat] = {
-      OrgRepo.repo.getMetadataFormats
+      repo.getMetadataFormats
     }
 
     def getDataSets: Seq[PublishedDataset] = {
-      OrgRepo.repo.getPublishedDatasets
+      repo.getPublishedDatasets
     }
 
     def exists(set: String, prefix: String): Boolean = {
@@ -72,15 +72,19 @@ object OaiPmh extends Controller {
     }
 
     def getFirstToken(set: String, prefix: String, headersOnly: Boolean, from: Option[DateTime], until: Option[DateTime]): Option[PMHResumptionToken] = {
-      OrgRepo.repo.datasetRepoOption(set).flatMap(repo => repo.recordDb(prefix).createHarvest(headersOnly, from, until))
+      repo.datasetRepoOption(set).flatMap { datasetRepo =>
+        datasetRepo.recordDbOpt.map(_.createHarvest(headersOnly, from, until))
+      }
     }
 
     def getHarvestValues(token: PMHResumptionToken, enriched: Boolean): (List[StoredRecord], Option[PMHResumptionToken]) = {
-      OrgRepo.repo.getHarvest(token, enriched)
+      repo.getHarvest(token, enriched)
     }
 
     def getRecord(set: String, prefix: String, identifier: String): Option[NodeSeq] = {
-      OrgRepo.repo.datasetRepoOption(set).flatMap(repo => repo.recordDb(prefix).recordPmh(identifier))
+      repo.datasetRepoOption(set).flatMap { datasetRepo =>
+        datasetRepo.recordDbOpt.map(_.recordPmh(identifier))
+      }
     }
   }
 

--- a/app/mapping/SkosRepo.scala
+++ b/app/mapping/SkosRepo.scala
@@ -17,24 +17,16 @@ package mapping
 
 import java.io.{File, FileInputStream}
 
-import services.NarthexConfig
-
-object SkosRepo {
-  lazy val repo: SkosRepo = new SkosRepo(NarthexConfig.USER_HOME)
-}
-
-class SkosRepo(userHome: String) {
+class SkosRepo(home: File) {
 
   val SUFFIX = ".xml"
-  val root = new File(userHome, "NarthexFiles")
-  val skos = new File(root, "skos")
 
   def listFiles = {
-    val files = if (skos.exists()) skos.listFiles.filter(file => file.getName.endsWith(SUFFIX)) else Array[File]()
+    val files = if (home.exists()) home.listFiles.filter(file => file.getName.endsWith(SUFFIX)) else Array[File]()
     files.map(file => file.getName.substring(0, file.getName.length - SUFFIX.length)).map(_.replaceAll("_", " "))
   }
 
-  def file(name: String) = new File(skos, name.replaceAll(" ", "_") + SUFFIX)
+  def file(name: String) = new File(home, name.replaceAll(" ", "_") + SUFFIX)
 
   def vocabulary(name: String) = SkosVocabulary(new FileInputStream(file(name)))
 

--- a/app/record/Saver.scala
+++ b/app/record/Saver.scala
@@ -26,9 +26,8 @@ import org.basex.core.cmd.{Delete, Optimize}
 import org.joda.time.DateTime
 import play.api.Logger
 import record.PocketParser.Pocket
-import record.Saver.{MappingContext, SaveComplete, SaveRecords}
+import record.Saver.{SaveComplete, SaveRecords}
 import services.SipFile.SipMapper
-import services.StringHandling.VERBATIM
 import services.{FileHandling, ProgressReporter}
 
 import scala.concurrent._
@@ -38,7 +37,7 @@ object Saver {
 
   case class SaveRecords(modifiedAfter: Option[DateTime], file: File,
                          recordRoot: String, uniqueId: String, recordCount: Long, deepRecordContainer: Option[String],
-                         sipMapper: Option[Seq[SipMapper]])
+                         sipMapper: Option[SipMapper])
 
   case class SaveComplete(errorOption: Option[String] = None)
 
@@ -60,98 +59,88 @@ class Saver(val datasetRepo: DatasetRepo) extends Actor {
     case InterruptWork() =>
       progress.map(_.bomb = Some(sender())).getOrElse(context.stop(self))
 
-    case SaveRecords(modifiedAfter: Option[DateTime], file, recordRoot, uniqueId, recordCount, deepRecordContainer, sipMappers) =>
+    case SaveRecords(modifiedAfter: Option[DateTime], file, recordRoot, uniqueId, recordCount, deepRecordContainer, sipMapper) =>
       log.info(s"Saving $datasetRepo modified=$modifiedAfter file=${file.getAbsolutePath})")
-      
-      // create a non-empty list of contexts with record db and optional mapper
-      val sipMappingContexts: Seq[MappingContext] = sipMappers.map(mapperList =>
-        mapperList.map(mapper =>
-          MappingContext(datasetRepo.recordDb(mapper.prefix), Some(mapper))
-        )
-      ).getOrElse(Seq(MappingContext(datasetRepo.recordDb(VERBATIM), None)))
+      val recordDb = datasetRepo.recordDbOpt.getOrElse(throw new RuntimeException(s"Expected record db for $datasetRepo"))
 
       val f: Future[Unit] = future {
-        
-        sipMappingContexts.map { mappingContext =>
 
-          modifiedAfter.map { after =>
-            val parser = new PocketParser(recordRoot, uniqueId, deepRecordContainer)
-            val (source, readProgress) = FileHandling.sourceFromFile(file)
-            val progressReporter = ProgressReporter(UPDATING, datasetRepo.datasetDb)
-            progressReporter.setReadProgress(readProgress)
-            progress = Some(progressReporter)
-            mappingContext.recordDb.withRecordDb { session =>
-              def receiveRecord(rawPocket: Pocket): Unit = {
-                val pocket = mappingContext.sipMapper.map(_.map(rawPocket)).getOrElse(rawPocket)
-                log.info(s"Updating ${pocket.id}")
-                mappingContext.recordDb.findRecord(pocket.id, session).map { foundRecord =>
-                  log.info(s"Record found $foundRecord, deleting it")
-                  if (pocket.hash == foundRecord.hash) {
-                    log.info(s"The new record has the same hash, but ignoring that for now")
-                  }
-                  else {
-                    log.info(s"The new record has a fresh hash")
-                  }
-                  session.execute(new Delete(foundRecord.path))
-                }
-                val path = datasetRepo.createPocketPath(pocket)
-                log.info(s"Adding $path")
-                session.add(path, pocket.textBytes)
-              }
-              try {
-                parser.parse(source, Set.empty[String], receiveRecord, progressReporter)
-                context.parent ! SaveComplete()
-              }
-              catch {
-                case e: Exception =>
-                  log.error(s"Unable to update $datasetRepo", e)
-                  context.parent ! SaveComplete(Some(e.toString))
-              }
-              finally {
-                source.close()
-              }
-            }
-          } getOrElse {
-            log.info(s"Saving file for $datasetRepo: ${file.getAbsolutePath}")
-            mappingContext.recordDb.createDb()
-            var tick = 0
-            var time = System.currentTimeMillis()
-            mappingContext.recordDb.withRecordDb { session =>
-              val parser = new PocketParser(recordRoot, uniqueId, deepRecordContainer)
-              val (source, readProgress) = FileHandling.sourceFromFile(file)
-              val progressReporter = ProgressReporter(SAVING, datasetRepo.datasetDb)
-              progressReporter.setReadProgress(readProgress)
-              progress = Some(progressReporter)
-              def receiveRecord(rawPocket: Pocket): Unit = {
-                val pocket = mappingContext.sipMapper.map(_.map(rawPocket)).getOrElse(rawPocket)
-                session.add(datasetRepo.createPocketPath(pocket), pocket.textBytes)
-                tick += 1
-                if (tick % 10000 == 0) {
-                  val now = System.currentTimeMillis()
-                  Logger.info(s"$datasetRepo $tick: ${now - time}ms")
-                  time = now
-                }
-              }
-              try {
-                if (parser.parse(source, Set.empty, receiveRecord, progressReporter)) {
-                  log.info(s"Saved ${datasetRepo.analyzedDir.getName}, optimizing..")
-                  mappingContext.recordDb.withRecordDb(_.execute(new Optimize()))
-                  datasetRepo.datasetDb.setNamespaceMap(parser.namespaceMap)
-                  context.parent ! SaveComplete()
+        modifiedAfter.map { after =>
+          val parser = new PocketParser(recordRoot, uniqueId, deepRecordContainer)
+          val (source, readProgress) = FileHandling.sourceFromFile(file)
+          val progressReporter = ProgressReporter(UPDATING, datasetRepo.datasetDb)
+          progressReporter.setReadProgress(readProgress)
+          progress = Some(progressReporter)
+          recordDb.withRecordDb { session =>
+            def receiveRecord(rawPocket: Pocket): Unit = {
+              val pocket = sipMapper.map(_.map(rawPocket)).getOrElse(rawPocket)
+              log.info(s"Updating ${pocket.id}")
+              recordDb.findRecord(pocket.id, session).map { foundRecord =>
+                log.info(s"Record found $foundRecord, deleting it")
+                if (pocket.hash == foundRecord.hash) {
+                  log.info(s"The new record has the same hash, but ignoring that for now")
                 }
                 else {
-                  context.parent ! SaveComplete(Some("Interrupted while saving"))
+                  log.info(s"The new record has a fresh hash")
                 }
+                session.execute(new Delete(foundRecord.path))
               }
-              catch {
-                case e: Exception =>
-                  log.error(s"Unable to save $datasetRepo", e)
-                  context.parent ! SaveComplete(Some(e.toString))
+              val path = datasetRepo.createPocketPath(pocket)
+              log.info(s"Adding $path")
+              session.add(path, pocket.textBytes)
+            }
+            try {
+              parser.parse(source, Set.empty[String], receiveRecord, progressReporter)
+              context.parent ! SaveComplete()
+            }
+            catch {
+              case e: Exception =>
+                log.error(s"Unable to update $datasetRepo", e)
+                context.parent ! SaveComplete(Some(e.toString))
+            }
+            finally {
+              source.close()
+            }
+          }
+        } getOrElse {
+          log.info(s"Saving file for $datasetRepo: ${file.getAbsolutePath}")
+          recordDb.createDb()
+          var tick = 0
+          var time = System.currentTimeMillis()
+          recordDb.withRecordDb { session =>
+            val parser = new PocketParser(recordRoot, uniqueId, deepRecordContainer)
+            val (source, readProgress) = FileHandling.sourceFromFile(file)
+            val progressReporter = ProgressReporter(SAVING, datasetRepo.datasetDb)
+            progressReporter.setReadProgress(readProgress)
+            progress = Some(progressReporter)
+            def receiveRecord(rawPocket: Pocket): Unit = {
+              val pocket = sipMapper.map(_.map(rawPocket)).getOrElse(rawPocket)
+              session.add(datasetRepo.createPocketPath(pocket), pocket.textBytes)
+              tick += 1
+              if (tick % 10000 == 0) {
+                val now = System.currentTimeMillis()
+                Logger.info(s"$datasetRepo $tick: ${now - time}ms")
+                time = now
               }
-              finally {
-                source.close()
+            }
+            try {
+              if (parser.parse(source, Set.empty, receiveRecord, progressReporter)) {
+                log.info(s"Saved ${datasetRepo.analyzedDir.getName}, optimizing..")
+                recordDb.withRecordDb(_.execute(new Optimize()))
+                datasetRepo.datasetDb.setNamespaceMap(parser.namespaceMap)
+                context.parent ! SaveComplete()
               }
-
+              else {
+                context.parent ! SaveComplete(Some("Interrupted while saving"))
+              }
+            }
+            catch {
+              case e: Exception =>
+                log.error(s"Unable to save $datasetRepo", e)
+                context.parent ! SaveComplete(Some(e.toString))
+            }
+            finally {
+              source.close()
             }
           }
         }

--- a/app/services/StringHandling.scala
+++ b/app/services/StringHandling.scala
@@ -48,22 +48,7 @@ object StringHandling {
       .replaceAll("[%]29", ")")
   }
 
-  val VERBATIM = "verbatim"
-
   def oaipmhPublishFromInfo(info: NodeSeq): Boolean = (info \ "publication" \ "oaipmh").text.trim == "true"
-
-  def oaipmhPrefixesFromInfo(info: NodeSeq): Option[Seq[String]] = {
-    val prefixes = (info \ "publication" \ "oaipmhPrefixes").text.trim
-    if (prefixes.nonEmpty)
-      if (oaipmhPublishFromInfo(info))
-        Some(prefixes.split("[\\s,;-]+").toSeq)
-      else
-        None
-    else if (oaipmhPublishFromInfo(info))
-      Some(Seq(VERBATIM))
-    else
-      None
-  }
 
   val SUFFIXES = List(".xml.gz", ".xml")
 
@@ -76,17 +61,4 @@ object StringHandling {
     val suffix = getSuffix(uploadedFileName)
     uploadedFileName.substring(0, uploadedFileName.length - suffix.length)
   }
-
-  object DatasetName{
-    def apply(name: String): DatasetName =  {
-      val sep = name.lastIndexOf("__")
-      if (sep > 0)
-        DatasetName(spec = name.substring(0, sep), prefix = name.substring(sep + 2))
-      else
-        DatasetName(spec = name, prefix = VERBATIM)
-    }
-  }
-
-  case class DatasetName(spec: String, prefix: String)
-
 }

--- a/conf/routes
+++ b/conf/routes
@@ -19,7 +19,7 @@ GET         /narthex/logout                                               web.Ap
 
 # File Handling
 GET         /narthex/dashboard/list                                       web.Dashboard.list
-POST        /narthex/dashboard/:datasetName/upload                        web.Dashboard.upload(datasetName)
+POST        /narthex/dashboard/:datasetName/upload/:prefix                web.Dashboard.upload(datasetName, prefix)
 POST        /narthex/dashboard/:datasetName/harvest                       web.Dashboard.harvest(datasetName)
 POST        /narthex/dashboard/:datasetName/set-harvest-cron              web.Dashboard.setHarvestCron(datasetName)
 POST        /narthex/dashboard/:datasetName/set-metadata                  web.Dashboard.setMetadata(datasetName)

--- a/public/templates/datasets.html
+++ b/public/templates/datasets.html
@@ -54,17 +54,30 @@
 </script>
 
 <script type="text/ng-template" id="drop-file.html">
-    <div class="file-drop" ng-file-drop="file.fileDropped($files)" ng-file-drag-over-class="file-drop-over">
-        <h6>Drag and drop your xml source file into this area</h6>
-        <div class="img-holder" data-ng-show="file.uploading">
-            <i class="busy1 fa fa-gear fa-spin fa-5x"></i>
-            <i class="busy2 fa fa-gear fa-spin-left fa-4x"></i>
-            <i class="busy3 fa fa-gear fa-spin-left fa-5x"></i>
+    <div>
+        <div class="col-md-6">
+            <form name="form" class="form file-harvest">
+                <fieldset>
+                    <div class="form-group">
+                        <label for="drop_prefix">Metadata format prefix:</label>
+                        <input id="drop_prefix" class="form-control" data-ng-model="file.prefix" placeholder="prefix" required/>
+                    </div>
+                </fieldset>
+            </form>
         </div>
-        <div data-ng-if="file.uploadPercent">
-            <progressbar class="progress-striped active" animate="true" value="file.uploadPercent" max="100" type="success">
-                <b>{{ file.uploadPercent }}%</b>
-            </progressbar>
+        <div class="file-drop col-md-6" ng-file-drop="file.fileDropped($files)" ng-file-drag-over-class="file-drop-over">
+            <span data-ng-show="!(file.prefix && file.prefix.length)">Prefix required</span>
+            <span data-ng-show="file.prefix && file.prefix.length">Drag and drop your xml source with <strong>"{{file.prefix}}"</strong> data into this area</span>
+            <div class="img-holder" data-ng-show="file.uploading">
+                <i class="busy1 fa fa-gear fa-spin fa-5x"></i>
+                <i class="busy2 fa fa-gear fa-spin-left fa-4x"></i>
+                <i class="busy3 fa fa-gear fa-spin-left fa-5x"></i>
+            </div>
+            <div data-ng-if="file.uploadPercent">
+                <progressbar class="progress-striped active" animate="true" value="file.uploadPercent" max="100" type="success">
+                    <b>{{ file.uploadPercent }}%</b>
+                </progressbar>
+            </div>
         </div>
     </div>
 </script>
@@ -153,10 +166,6 @@
 <script type="text/ng-template" id="publication-form.html">
     <form name="form" class="form">
         <fieldset>
-            <div class="form-group">
-                <label for="pub_pmh_prefix">Metadata Formats</label>
-                <input id="pub_pmh_prefix" class="form-control" data-ng-model="file.info.publication.oaipmhPrefixes" placeholder="prefix list"/>
-            </div>
             <div class="checkbox">
                 <label for="pub_pmh">Publish via OAI-PMH
                     <input id="pub_pmh" type="checkbox" data-ng-model="file.info.publication.oaipmh" ng-true-value="'true'" ng-false-value="'false'"/>
@@ -199,14 +208,14 @@
                 <i class="fa fa-download"></i> Terminology Mappings
             </a>
         </li>
-        <li data-ng-repeat="prefixUrl in file.oaiPmhListRecords">
-            <a class="" ng-href="{{ prefixUrl.url }}" target="_blank">
-                <i class="fa fa-download"></i> Records with format "{{ prefixUrl.prefix }}"
+        <li data-ng-show="file.oaiPmhListRecords">
+            <a class="" ng-href="{{ file.oaiPmhListRecords.url }}" target="_blank">
+                <i class="fa fa-download"></i> Records with format "{{ file.oaiPmhListRecords.prefix }}"
             </a>
         </li>
-        <li data-ng-repeat="prefixUrl in file.oaiPmhListEnrichedRecords">
-            <a class="" ng-href="{{ prefixUrl.url }}" target="_blank">
-                <i class="fa fa-download"></i> Enriched Records with format "{{ prefixUrl.prefix }}"
+        <li data-ng-show="file.oaiPmhListEnrichedRecords">
+            <a class="" ng-href="{{ file.oaiPmhListEnrichedRecords.url }}" target="_blank">
+                <i class="fa fa-download"></i> Enriched Records with format "{{ file.oaiPmhListEnrichedRecords.prefix }}"
             </a>
         </li>
     </ul>
@@ -322,10 +331,10 @@
 
             <span ng-if="file.origin">
                 <span ng-switch="file.origin">
-                    <span class="label label-default" ng-switch-when="origin-drop">Dropped file</span>
-                    <span class="label label-default" ng-switch-when="origin-harvest">Harvested dataset</span>
-                    <span class="label label-default" ng-switch-when="origin-sip-source">SIP File with source</span>
-                    <span class="label label-default" ng-switch-when="origin-sip-harvest">SIP File with harvest</span>
+                    <span class="label label-default" ng-switch-when="origin-drop">Dropped file ({{ file.prefix }})</span>
+                    <span class="label label-default" ng-switch-when="origin-harvest">Harvested dataset ({{ file.prefix }})</span>
+                    <span class="label label-default" ng-switch-when="origin-sip-source">SIP File with source ({{ file.prefix }})</span>
+                    <span class="label label-default" ng-switch-when="origin-sip-harvest">SIP File with harvest ({{ file.prefix }})</span>
                     <span class="label label-default" ng-switch-default>Unknown origin</span>
                 </span>
             </span>
@@ -397,7 +406,7 @@
                         <a href role="tab" data-ng-click="setTabOpen('info')">Info</a>
                     </li>
                 </ul>
-                <div class="tab-content col-md-4">
+                <div class="tab-content col-md-6">
                     <div ng-switch="tabOpen">
                         <div ng-switch-when="metadata"><div data-ng-include="'metadata-form.html'">metadata form</div></div>
                         <div ng-switch-when="drop"><div data-ng-include="'drop-file.html'">drop file</div></div>

--- a/test/specs/TestCategoryParser.scala
+++ b/test/specs/TestCategoryParser.scala
@@ -5,7 +5,6 @@ import java.io.{File, FileOutputStream}
 import mapping.CategoryDb
 import org.scalatest.{FlatSpec, Matchers}
 import record.CategoryParser
-import record.CategoryParser.CategoryCountCollection
 import services.{FileHandling, ProgressReporter}
 
 class TestCategoryParser extends FlatSpec with Matchers {
@@ -56,12 +55,12 @@ class TestCategoryParser extends FlatSpec with Matchers {
     println(s"cat map $countList")
     reply should be(true)
     categoryParser.recordCount should be(4724)
-    countList.size should be(10)
+    countList.size should be(13)
 
     val home = new File(System.getProperty("user.home"))
     val excel = new File(home, "categories.xlsx")
     val fos = new FileOutputStream(excel)
-    CategoryCountCollection(countList).categoriesPerDataset.write(fos)
+    CategoryParser.generateWorkbook(countList).write(fos)
     fos.close()
   }
 }

--- a/test/specs/TestSipRepo.scala
+++ b/test/specs/TestSipRepo.scala
@@ -29,11 +29,11 @@ class TestSipRepo extends FlatSpec with Matchers {
 
       sipFile.uniqueElementPath should be(Some("/harvest/OAI-PMH/ListRecords/record/metadata/arno:document/arno:document-admin/arno:doc_id"))
 
-      sipFile.schemaVersionSeq.size should be(1)
+      sipFile.schemaVersionOpt.isDefined should be(true)
 
       var mappedPockets = List.empty[Pocket]
 
-      sipFile.createSipMapper("tib") map { sipMapper =>
+      sipFile.createSipMapper map { sipMapper =>
         def pocketCatcher(pocket: Pocket): Unit = {
           var mappedPocket = sipMapper.map(pocket)
           mappedPockets = mappedPocket :: mappedPockets

--- a/test/specs/TestTermMatching.scala
+++ b/test/specs/TestTermMatching.scala
@@ -65,7 +65,7 @@ class TestTermMatching extends FlatSpec with Matchers {
         |<record xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:very="http://veryother.org/#">
         |  <inner>
         |    <content.subject>
-        |      <rdf:Description>
+        |      <rdf:Description rdf:about="gerald_delving_eu/RCE_Beeldbank/record/inner/content.subject/Glas%20in%20loodraam">
         |        <rdfs:label>Glas in loodraam</rdfs:label>
         |        <skos:prefLabel>glasinloody</skos:prefLabel>
         |        <skos:exactMatch rdf:resource="uri"/>


### PR DESCRIPTION
...DatasetOrigin, and VERBATIM is gone.

File upload now requires a prefix, so there's a form field to make drop possible.
DatasetRepo now has recordDbOpt which gives you one for the dataset's prefix.
SkosRepo moved to org dir from global.
