### PR TITLE
Boyscout: solve sbt resolver warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ publishArtifact in(Compile, packageDoc) := false
 
 publishArtifact in(Compile, packageSrc) := false
 
-publishTo := Some("Delving" at "http://artifactory.delving.org/artifactory/delving")
+publishTo := Some("DelvingPublish" at "http://artifactory.delving.org/artifactory/delving")
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 


### PR DESCRIPTION
My sbt complained (maybe that was due to my local setup?). Anyway, it was easy enough to fix so here's a PR if you're interested.

> [warn] Multiple resolvers having different access mechanism configured with same name 'Delving'. To avoid conflict, Remove duplicate project resolvers (`resolvers`) or rename publishing resolver (`publishTo`).

