### PR TITLE
Add support for harvesting Anet/Brocade OAI-PMH targets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added 
+
+- Support for harvesting Anet.be/Brocade OAI-PMH targets [[GH-153]](https://github.com/delving/narthex/pull/153)
+
 ## v0.6.0 (2020-07-22)
 
 ### Added 

--- a/app/harvest/Harvesting.scala
+++ b/app/harvest/Harvesting.scala
@@ -199,7 +199,13 @@ trait Harvesting {
           case _ => withSet
         }
       case Some(token) =>
-        listRecords.withQueryString("resumptionToken" -> token.value)
+        if (url.contains("anet.be")) {
+          listRecords
+            .withQueryString("resumptionToken" -> token.value)
+            .withQueryString("metadataPrefix" -> metadataPrefix) 
+        } else {
+          listRecords.withQueryString("resumptionToken" -> token.value)
+        }
     }
     
     // define your success condition


### PR DESCRIPTION
Brocade requires metadatPrefix when paging with resumptionTokens.