### PR TITLE
Feature/local id extraction fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## v0.6.1 (2020-09-29)
+## v0.6.2 (2021-11-01)
+
+## Fixed
+
+* localID was not correctly extracted for NA /doc based URIS [[GH-154]](https://github.com/delving/narthex/pull/154)
+
+## v0.6.1 (2021-09-29)
 
 ### Added 
 
 * Support for harvesting Anet.be/Brocade OAI-PMH endpoints [[GH-153]](https://github.com/delving/narthex/pull/153)
 
-## v0.6.0 (2020-07-22)
+## v0.6.0 (2021-07-22)
 
 ### Added 
 

--- a/app/dataset/DsInfo.scala
+++ b/app/dataset/DsInfo.scala
@@ -651,7 +651,7 @@ class DsInfo(
 	  return (toString, localId)
     }
 	val SpecIdExtractor =
-	  "http://.*?/resource/aggregation/([^/]+)/([^/]+)/graph".r
+	  "http[s]{0,1}://.*?/resource/aggregation/([^/]+)/([^/]+)/graph".r
 	val SpecIdExtractor(spec, localId) = id
 	(spec, localId)
   }

--- a/app/dataset/DsInfo.scala
+++ b/app/dataset/DsInfo.scala
@@ -646,8 +646,8 @@ class DsInfo(
 
   def extractSpecIdFromGraphName(id: String): (String, String) = {
     if (id contains "/doc/") {
-	  val localId = id.split("/doc/").last.stripSuffix("/graph").trim
-	  //Logger.info(s"localID: $localId")
+	  val localId = id.stripSuffix("/graph").split("/doc/").last.split("/").last.trim
+      // Logger.info(s"localID: $localId")
 	  return (toString, localId)
     }
 	val SpecIdExtractor =

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.1"
+version in ThisBuild := "0.6.2"


### PR DESCRIPTION
Fixed incorrect localID for NA /doc based URLs.

Previously everything before the slash was extracted, which lead to invalid hubIDs being submitted for indexing.