### PR TITLE
Feature/bootstap webjar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-* upgrade build dependency for bootstrap webjars
+* upgrade build dependency for bootstrap webjars [[GH127]](https://github.com/delving/narthex/pull/157)
  
 - history of changes: see https://github.com/delving/narthex/compare/v0.6.4...v0.6.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - history of changes: see https://github.com/delving/narthex/compare/v0.6.4...master
 
-## v0.6.4 (2022-01-06)
+## [Unreleased]
+
+- history of changes: see https://github.com/delving/narthex/compare/v0.6.4...master
+
+## v0.6.5 (2022-03-07)
 
 ## Added
 
 * bump version of sip-core [[GH-156]](https://github.com/delving/narthex/pull/156)
+
+## Fixed
+
+* upgrade build dependency for bootstrap webjars
 
 ## v0.6.3 (2022-01-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- history of changes: see https://github.com/delving/narthex/compare/v0.6.4...master
+- history of changes: see https://github.com/delving/narthex/compare/v0.6.5...master
 
-## [Unreleased]
-
-- history of changes: see https://github.com/delving/narthex/compare/v0.6.4...master
 
 ## v0.6.5 (2022-03-07)
 
@@ -21,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 * upgrade build dependency for bootstrap webjars
+ 
+- history of changes: see https://github.com/delving/narthex/compare/v0.6.4...v0.6.5
 
 ## v0.6.3 (2022-01-03)
 

--- a/app/web/SipAppController.scala
+++ b/app/web/SipAppController.scala
@@ -52,9 +52,9 @@ class SipAppController(val orgContext: OrgContext)
   }
 
   def downloadSipZip(spec: String) = Action { request =>
-    Logger.debug(s"Download sip-zip $spec")
+    Logger.debug(s"Download sip-zip '$spec'")
     val sipFileOpt = orgContext.datasetContext(spec).sipFiles.headOption
-    sipFileOpt.map(Utils.okFile(_)).getOrElse(NotFound(s"No sip-zip for $spec"))
+    sipFileOpt.map(Utils.okFile(_).withHeaders(s"Content-Disposition" -> s"attachment; filename=$spec.sip.zip")).getOrElse(NotFound(s"No sip-zip for $spec"))
   }
 
   def uploadSipZip(spec: String, zipFileName: String) = Action(parse.temporaryFile) { request =>

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ buildInfoKeys ++= Seq[BuildInfoKey](
 
 libraryDependencies ++= Seq(
   "org.webjars" %% "webjars-play" % "2.5.0-3",
-  "org.webjars" % "bootstrap" % "3.1.1-2",
+  "org.webjars" % "bootstrap" % "3.2.0",
   "org.webjars" % "underscorejs" % "1.8.3",
   "org.webjars" % "jquery" % "2.1.1",
   "org.webjars" % "angularjs" % "1.3.17",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.4"
+version in ThisBuild := "0.6.5"


### PR DESCRIPTION
jsdeliver CDN renamed bootstrap webjar. This pull request upgrades to a working version and adds improvement for downloading sip-zips with correct file-names.

Without this fix production versions will stop rendering the web-interface.