### PR TITLE
Replace `oai_dc:dc` metadata root with `record`.

### DIFF
--- a/app/record/PocketParser.scala
+++ b/app/record/PocketParser.scala
@@ -208,7 +208,11 @@ class PocketParser(facts: SourceFacts,
             val cleanId = cleanUpId(id)
             if (avoid.contains(cleanId)) None
             else {
-              val recordContent = recordText.toString()
+              var recordContent = recordText.toString()
+              // only replace for NAA data
+              if (recordContent.contains("identifier.hyph-guid")) {
+                recordContent = recordContent.replaceAll("oai_dc:dc", "record")
+              }
               val scope = namespaceMap.view
                 .filter(_._1 != null)
                 .map(kv => s"""xmlns:${kv._1}="${kv._2}" """)

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "log4j-over-slf4j" % "1.7.21",
   "org.easybatch" % "easybatch-apache-commons-csv" % "3.0.0",
   "com.typesafe.play" %% "play-mailer" % "5.0.0",
-  "eu.delving" % "sip-core" % "1.2.3",
+  "eu.delving" % "sip-core" % "1.2.6",
   "de.threedimensions" %% "metrics-play" % "2.5.13",
   "com.getsentry.raven" % "raven-logback" % "7.6.0" % "runtime",
   "nl.grons" %% "metrics-scala" % "3.5.5_a2.3",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.5"
+version in ThisBuild := "0.6.6"


### PR DESCRIPTION
For datasets of the Dutch National Archive that use
'identifier.hyph-guid' as identifier `oai_dc:dc` must be replaced with
`record`. This allows the to transition from file-drop to oai-pmh
without having to remap the datasets.