### PR TITLE
Add support for index tags to the narthex dataset.

### DIFF
--- a/app/assets/javascripts/datasetList/dataset-list-controllers.js
+++ b/app/assets/javascripts/datasetList/dataset-list-controllers.js
@@ -329,7 +329,7 @@ define(["angular"], function () {
     // these lists must match with DsInfo.scala
 
     var metadataFields = [
-        "datasetName", "datasetDescription", "datasetAggregator", "datasetOwner", "datasetLanguage", "datasetRights", "datasetType", "edmType", "datasetDataProviderURL"
+        "datasetName", "datasetDescription", "datasetAggregator", "datasetOwner", "datasetLanguage", "datasetRights", "datasetType", "datasetTags", "edmType", "datasetDataProviderURL"
     ];
 
     var harvestFields = [

--- a/app/dataset/DsInfo.scala
+++ b/app/dataset/DsInfo.scala
@@ -611,7 +611,6 @@ class DsInfo(
   override def toString = spec
 
   val bulkApi = s"${naveApiUrl}/api/index/bulk/"
-  //val bulkApi = "https://europe-west1-prod-hubs-delving-io.cloudfunctions.net/bulkingestion"
 
   private def checkUpdateResponse(response: WSResponse,
                                   logString: String): Unit = {
@@ -647,13 +646,8 @@ class DsInfo(
   }
 
   def extractSpecIdFromGraphName(id: String): (String, String) = {
-    if (id contains "/doc/") {
-	  val localId = id.stripSuffix("/graph").split("/doc/").last.split("/").last.trim
-      // Logger.info(s"localID: $localId")
-	  return (toString, localId)
-    }
 	val SpecIdExtractor =
-	  "http[s]{0,1}://.*?/resource/aggregation/([^/]+)/([^/]+)/graph".r
+	  "http[s]{0,1}://.*?/([^/]+)/([^/]+)/graph".r
 	val SpecIdExtractor(spec, localId) = id
 	(spec, localId)
   }

--- a/app/dataset/ProcessedRepo.scala
+++ b/app/dataset/ProcessedRepo.scala
@@ -59,6 +59,7 @@ object ProcessedRepo {
 		  "dataset" -> spec,
 		  "graphUri" -> graphUri,
 		  "type" -> dsInfo.getLiteralProp(datasetType).getOrElse("narthex_record").toString(),
+		  "tags" -> dsInfo.getLiteralProp(datasetTags).getOrElse("").toString(),
 		  "action" -> "index",
           "graphMimeType" -> "application/ld+json",
 		  //"contentHash" -> localHash.toString,

--- a/app/dataset/SipRepo.scala
+++ b/app/dataset/SipRepo.scala
@@ -337,14 +337,13 @@ class Sip(val dsInfoSpec: String, rdfBaseUrl: String, val file: File) {
           val about = aggregation.getAttributes.getNamedItemNS(RDF_URI, RDF_ABOUT_ATTRIBUTE)
           val aggregationUri = about.getTextContent
           (rdfWrapper, StringHandling.createGraphName(aggregationUri))
-
         case _ =>
-          val rdfElement = doc.createElementNS(RDF_URI, s"$RDF_PREFIX:$RDF_RECORD_TAG")
-          val rdfAbout = s"$rdfBaseUrl/resource/graph/$datasetName/${urlEncodeValue(pocket.id)}"
-          rdfElement.setAttributeNS(RDF_URI, s"$RDF_PREFIX:$RDF_ABOUT_ATTRIBUTE", rdfAbout)
-          kids.foreach(rdfElement.appendChild)
-          val graphName = rdfAbout
-          (rdfElement, graphName)
+          val rdfWrapper = doc.createElementNS(RDF_URI, s"$RDF_PREFIX:$RDF_ROOT_TAG")
+          kids.foreach(rdfWrapper.appendChild)
+          val aggregation = kids.head
+          val about = aggregation.getAttributes.getNamedItemNS(RDF_URI, RDF_ABOUT_ATTRIBUTE)
+          val aggregationUri = about.getTextContent
+          (rdfWrapper, StringHandling.createGraphName(aggregationUri))
       }
       // deliver the pocket
       val xml = serializer.toXml(rootNode, true).replaceFirst("<[?].*[?]>\n", "")

--- a/app/init/MyApplicationLoader.scala
+++ b/app/init/MyApplicationLoader.scala
@@ -88,7 +88,7 @@ class MyComponents(context: Context, narthexDataDir: File, datadogConfig: Option
 
   LoggerConfigurator(context.environment.classLoader).foreach { _.configure(context.environment) }
 
-  val allSupportedDatasetTypes = Set("narthex","rdf","nt","photo","ead")
+  val allSupportedDatasetTypes = Set("narthex","rdf","nt","photo","ead", "fragmentsOnly")
   val appConfig = initAppConfig(narthexDataDir)
 
   val tripleStoreUrl = configStringNoSlash("triple-store")

--- a/app/triplestore/GraphProperties.scala
+++ b/app/triplestore/GraphProperties.scala
@@ -64,6 +64,7 @@ object GraphProperties {
   val datasetDataProviderURL = NXProp("datasetDataProviderURL")
   val datasetAggregator = NXProp("datasetAggregator")
   val datasetType = NXProp("datasetType")
+  val datasetTags = NXProp("datasetTags")
   val edmType = NXProp("edmType")
 
   val datasetLanguage = NXProp("datasetLanguage")

--- a/public/templates/dataset-list.html
+++ b/public/templates/dataset-list.html
@@ -14,102 +14,181 @@
     <div class="actions">
         <form action="" class="form-inline">
             <div class="form-group">
-                <a href class="btn btn-default" data-ng-click="newFileOpen = true">
+                <a
+                    href
+                    class="btn btn-default"
+                    data-ng-click="newFileOpen = true"
+                >
                     <i class="fa fa-star"></i> New Dataset
                 </a>
-                <a href class="btn btn-info" data-ng-click="openAllDatasets = !openAllDatasets">
+                <a
+                    href
+                    class="btn btn-info"
+                    data-ng-click="openAllDatasets = !openAllDatasets"
+                >
                     <i class="fa fa-bars"></i> Open/Close All
                 </a>
             </div>
         </form>
-
     </div>
 </div>
 
-<div class="toolbar">	
-    <form class="form-inline">	
-        <div class="form-group">	
-            <span class="dropdown">	
-                <button id="order-button" type="button" class="btn btn-default" dropdown-toggle ng-disabled="disabled">	
-                    Order by <span class="caret"></span>	
-                </button>	
-                <ul class="dropdown-menu" role="menu" aria-labelledby="single-button">	
-                    <li role="menuitem">	
-                        <a href data-ng-click="datasetListOrder('spec')">Spec</a>	
-                    </li>	
-                    <li role="menuitem">	
-                        <a href data-ng-click="datasetListOrder('state')">State</a>	
-                    </li>	
-                    <li role="menuitem">	
-                        <a href data-ng-click="datasetListOrder('lastmodified')">Date last modified</a>	
-                    </li>	
-                </ul>	
-            </span>	
-        </div>	
-        <div class="form-group">	
-            <div class="dropdown">	
-                <button id="state-filter-button" type="button" class="btn btn-default" dropdown-toggle ng-disabled="disabled">	
-                    Filter by state <span class="caret"></span>	
-                </button>	
-                <ul class="dropdown-menu" role="menu" aria-labelledby="single-button">	
-                    <li data-ng-repeat="state in datasetStates" role="menuitem">	
-                        <a href data-ng-click="setStateFilter(state.name)">{{ state.label }} ({{ state.count }})</a>	
-                    </li>	
-                    <li role="menuitem">	
-                        <a href data-ng-click="stateFilter = ''">Reset</a>	
-                    </li>	
-                </ul>	
-            </div>	
-        </div>	
-        <div class="form-group">	
-            <input type="text" class="form-control" data-ng-model="specOrNameFilter" placeholder="Filter by Spec or Name"/>	
-        </div>	
-    </form>	
+<div class="toolbar">
+    <form class="form-inline">
+        <div class="form-group">
+            <span class="dropdown">
+                <button
+                    id="order-button"
+                    type="button"
+                    class="btn btn-default"
+                    dropdown-toggle
+                    ng-disabled="disabled"
+                >
+                    Order by <span class="caret"></span>
+                </button>
+                <ul
+                    class="dropdown-menu"
+                    role="menu"
+                    aria-labelledby="single-button"
+                >
+                    <li role="menuitem">
+                        <a href data-ng-click="datasetListOrder('spec')"
+                            >Spec</a
+                        >
+                    </li>
+                    <li role="menuitem">
+                        <a href data-ng-click="datasetListOrder('state')"
+                            >State</a
+                        >
+                    </li>
+                    <li role="menuitem">
+                        <a href data-ng-click="datasetListOrder('lastmodified')"
+                            >Date last modified</a
+                        >
+                    </li>
+                </ul>
+            </span>
+        </div>
+        <div class="form-group">
+            <div class="dropdown">
+                <button
+                    id="state-filter-button"
+                    type="button"
+                    class="btn btn-default"
+                    dropdown-toggle
+                    ng-disabled="disabled"
+                >
+                    Filter by state <span class="caret"></span>
+                </button>
+                <ul
+                    class="dropdown-menu"
+                    role="menu"
+                    aria-labelledby="single-button"
+                >
+                    <li data-ng-repeat="state in datasetStates" role="menuitem">
+                        <a href data-ng-click="setStateFilter(state.name)"
+                            >{{ state.label }} ({{ state.count }})</a
+                        >
+                    </li>
+                    <li role="menuitem">
+                        <a href data-ng-click="stateFilter = ''">Reset</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="form-group">
+            <input
+                type="text"
+                class="form-control"
+                data-ng-model="specOrNameFilter"
+                placeholder="Filter by Spec or Name"
+            />
+        </div>
+    </form>
 </div>
 
 <div class="file-list datasets">
-
     <div data-ng-if="!datasets.length" class="col-md-12">
         <h4>No datasets</h4>
     </div>
     <table class="dataset-list-table">
         <thead>
-        <tr>
-            <th class="spec">Spec</th>
-            <th class="name">Display name</th>
-            <th class="error">In error</th>
-            <th class="valid">Valid</th>
-            <th class="total">Total</th>
-            <th class="status">Status</th>
-            <th class="date-time">Last changed</th>
-        </tr>
+            <tr>
+                <th class="spec">Spec</th>
+                <th class="name">Display name</th>
+                <th class="error">In error</th>
+                <th class="valid">Valid</th>
+                <th class="total">Total</th>
+                <th class="status">Status</th>
+                <th class="date-time">Last changed</th>
+            </tr>
         </thead>
     </table>
-    <div class="vertical-scroll" data-scrollable id="dataset-list" data-offset="160">
-        <div ng-repeat="dataset in datasets | filter: datasetVisibleFilter" class="" >
-            <div data-ng-controller="DatasetEntryCtrl" >
-                <table class="dataset-list-table" >
+    <div
+        class="vertical-scroll"
+        data-scrollable
+        id="dataset-list"
+        data-offset="160"
+    >
+        <div
+            ng-repeat="dataset in datasets | filter: datasetVisibleFilter"
+            class=""
+        >
+            <div data-ng-controller="DatasetEntryCtrl">
+                <table class="dataset-list-table">
                     <tbody>
-                    <tr data-spec="{{dataset.datasetSpec}}" data-ng-click="expanded = !expanded" class="clickable" data-ng-class="{ 'closed': !expanded, 'open': expanded }">
-                        <td class="spec">
-                            <span class="spec-field">{{ dataset.datasetSpec }}</span>
-                        </td>
-                        <td class="name">
-                            <span data-ng-show="dataset.datasetName" class="name-field">{{ dataset.datasetName }}</span>
-                        </td>
-                        <td class="error">
-                            <span data-ng-if="dataset.harvestIncrementalMode == 'true'">{{ dataset.processedIncrementalInvalid }} (inc)</span>
-                            <span data-ng-if="!dataset.harvestIncrementalMode || dataset.harvestIncrementalMode == 'false'">{{ dataset.processedInvalid }}</span>
-                        </td>
-                        <td class="valid">
-                            <span data-ng-if="dataset.harvestIncrementalMode == 'true'">{{ dataset.processedIncrementalValid }} (inc)</span>
-                            <span data-ng-if="!dataset.harvestIncrementalMode || dataset.harvestIncrementalMode == 'false'">{{ dataset.processedValid }}</span>
-                        </td>
-                        <td class="total">
-                            {{ dataset.datasetRecordCount }}
-                        </td>
-                        <td class="status">
-                            <span ng-switch="dataset.stateCurrent.name" class="indicator" data-ng-class="{stateEmpty:'empty',
+                        <tr
+                            data-spec="{{ dataset.datasetSpec }}"
+                            data-ng-click="expanded = !expanded"
+                            class="clickable"
+                            data-ng-class="{ 'closed': !expanded, 'open': expanded }"
+                        >
+                            <td class="spec">
+                                <span class="spec-field">{{
+                                    dataset.datasetSpec
+                                }}</span>
+                            </td>
+                            <td class="name">
+                                <span
+                                    data-ng-show="dataset.datasetName"
+                                    class="name-field"
+                                    >{{ dataset.datasetName }}</span
+                                >
+                            </td>
+                            <td class="error">
+                                <span
+                                    data-ng-if="dataset.harvestIncrementalMode == 'true'"
+                                    >{{
+                                        dataset.processedIncrementalInvalid
+                                    }}
+                                    (inc)</span
+                                >
+                                <span
+                                    data-ng-if="!dataset.harvestIncrementalMode || dataset.harvestIncrementalMode == 'false'"
+                                    >{{ dataset.processedInvalid }}</span
+                                >
+                            </td>
+                            <td class="valid">
+                                <span
+                                    data-ng-if="dataset.harvestIncrementalMode == 'true'"
+                                    >{{
+                                        dataset.processedIncrementalValid
+                                    }}
+                                    (inc)</span
+                                >
+                                <span
+                                    data-ng-if="!dataset.harvestIncrementalMode || dataset.harvestIncrementalMode == 'false'"
+                                    >{{ dataset.processedValid }}</span
+                                >
+                            </td>
+                            <td class="total">
+                                {{ dataset.datasetRecordCount }}
+                            </td>
+                            <td class="status">
+                                <span
+                                    ng-switch="dataset.stateCurrent.name"
+                                    class="indicator"
+                                    data-ng-class="{stateEmpty:'empty',
                                             stateRaw: 'raw',
                                             stateRawAnalyzed: 'raw-analyzed',
                                             stateSourced: 'sourced',
@@ -121,122 +200,236 @@
                                             stateAnalyzed: 'analyzed',
                                             stateSaved:'saved',
                                             stateDisabled:'disabled',
-                                            '':'default'}[dataset.stateCurrent.name]">
-                                <span ng-switch-when="stateRaw">Raw source</span>
-                                <span ng-switch-when="stateRawAnalyzed">Raw source analyzed</span>
-                                <span ng-switch-when="stateSourced">Sourced</span>
-                                <span ng-switch-when="stateMappable">Mappable</span>
-                                <span ng-switch-when="stateProcessable">Processable</span>
-                                <span ng-switch-when="stateIncrementalSaved">Incremental Processed</span>
-                                <span ng-switch-when="stateInError">Processing error</span>
-                                <span ng-switch-when="stateProcessed">Processed</span>
-                                <span ng-switch-when="stateAnalyzed">Analyzed</span>
-                                <span ng-switch-when="stateSaved">Saved</span>
-                                <span ng-switch-when="stateDisabled">Disabled</span>
-                                <span ng-switch-default>Empty</span>
-                            </span>
-
-                        </td>
-                        <td class="date-time">
-                            {{ dataset.stateCurrent.date | date:"yyyy/MM/dd HH:mm" }}
-                        </td>
-                    </tr>
+                                            '':'default'}[dataset.stateCurrent.name]"
+                                >
+                                    <span ng-switch-when="stateRaw"
+                                        >Raw source</span
+                                    >
+                                    <span ng-switch-when="stateRawAnalyzed"
+                                        >Raw source analyzed</span
+                                    >
+                                    <span ng-switch-when="stateSourced"
+                                        >Sourced</span
+                                    >
+                                    <span ng-switch-when="stateMappable"
+                                        >Mappable</span
+                                    >
+                                    <span ng-switch-when="stateProcessable"
+                                        >Processable</span
+                                    >
+                                    <span ng-switch-when="stateIncrementalSaved"
+                                        >Incremental Processed</span
+                                    >
+                                    <span ng-switch-when="stateInError"
+                                        >Processing error</span
+                                    >
+                                    <span ng-switch-when="stateProcessed"
+                                        >Processed</span
+                                    >
+                                    <span ng-switch-when="stateAnalyzed"
+                                        >Analyzed</span
+                                    >
+                                    <span ng-switch-when="stateSaved"
+                                        >Saved</span
+                                    >
+                                    <span ng-switch-when="stateDisabled"
+                                        >Disabled</span
+                                    >
+                                    <span ng-switch-default>Empty</span>
+                                </span>
+                            </td>
+                            <td class="date-time">
+                                {{
+                                    dataset.stateCurrent.date
+                                        | date: 'yyyy/MM/dd HH:mm'
+                                }}
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
 
-
-                <div ng-if="expanded" class="dataset-metadata" data-ng-class="{ 'closed': !expanded, 'expanded': expanded }">
+                <div
+                    ng-if="expanded"
+                    class="dataset-metadata"
+                    data-ng-class="{ 'closed': !expanded, 'expanded': expanded }"
+                >
                     <div class="dataset-states col-md-3">
                         <ul class="list-group states">
-                            <li data-ng-show="dataset.stateRaw" class="ds-state list-group-item"
-                                data-ng-class="{ 'later': isCurrent('stateRaw') }">
-                                <h4 class="list-group-item-heading">Raw
-                                    <small class="badge">{{ dataset.stateRaw.d }} {{ dataset.stateRaw.t }}</small>
+                            <li
+                                data-ng-show="dataset.stateRaw"
+                                class="ds-state list-group-item"
+                                data-ng-class="{ 'later': isCurrent('stateRaw') }"
+                            >
+                                <h4 class="list-group-item-heading">
+                                    Raw
+                                    <small class="badge"
+                                        >{{ dataset.stateRaw.d }}
+                                        {{ dataset.stateRaw.t }}</small
+                                    >
                                 </h4>
                                 <div class="btn-toolbar">
-                                    <a href data-ng-click="start('start raw analysis')">
-                                        <i class="fa fa-fw fa-bar-chart"></i> <span>Analyze</span>
+                                    <a
+                                        href
+                                        data-ng-click="start('start raw analysis')"
+                                    >
+                                        <i class="fa fa-fw fa-bar-chart"></i>
+                                        <span>Analyze</span>
                                     </a>
                                 </div>
                             </li>
-                            <li data-ng-show="dataset.stateRawAnalyzed" class="ds-state list-group-item"
-                                data-ng-class="{ 'later': isCurrent('stateRawAnalyzed') }">
-                                <h4 class="list-group-item-heading">Raw Analyzed
-                                    <small class="badge">{{ dataset.stateRawAnalyzed.d }} {{ dataset.stateRawAnalyzed.t | date:"HH:mm"}}</small>
-
+                            <li
+                                data-ng-show="dataset.stateRawAnalyzed"
+                                class="ds-state list-group-item"
+                                data-ng-class="{ 'later': isCurrent('stateRawAnalyzed') }"
+                            >
+                                <h4 class="list-group-item-heading">
+                                    Raw Analyzed
+                                    <small class="badge"
+                                        >{{ dataset.stateRawAnalyzed.d }}
+                                        {{
+                                            dataset.stateRawAnalyzed.t
+                                                | date: 'HH:mm'
+                                        }}</small
+                                    >
                                 </h4>
                                 <div class="btn-toolbar">
                                     <a href data-ng-click="goToDataset()">
-                                        <i class="fa fa-fw fa-eye"></i> <span>Delimit</span>
+                                        <i class="fa fa-fw fa-eye"></i>
+                                        <span>Delimit</span>
                                     </a>
                                 </div>
                             </li>
-                            <li data-ng-show="dataset.stateSourced" class="ds-state list-group-item"
-                                data-ng-class="{ 'later': isCurrent('stateSourced') }">
-                                <h4 class="list-group-item-heading">Sourced
-                                    <small class="badge">{{ dataset.stateSourced.d }} {{ dataset.stateSourced.t }}</small>
+                            <li
+                                data-ng-show="dataset.stateSourced"
+                                class="ds-state list-group-item"
+                                data-ng-class="{ 'later': isCurrent('stateSourced') }"
+                            >
+                                <h4 class="list-group-item-heading">
+                                    Sourced
+                                    <small class="badge"
+                                        >{{ dataset.stateSourced.d }}
+                                        {{ dataset.stateSourced.t }}</small
+                                    >
                                 </h4>
                                 <div class="btn-toolbar">
-                                    <a href data-ng-click="start('start generating sip')">
-                                        <i class="fa fa-fw fa-cube"></i> <span>Make SIP</span>
+                                    <a
+                                        href
+                                        data-ng-click="start('start generating sip')"
+                                    >
+                                        <i class="fa fa-fw fa-cube"></i>
+                                        <span>Make SIP</span>
                                     </a>
                                 </div>
                             </li>
-                            <li data-ng-show="dataset.stateMappable" class="ds-state list-group-item"
-                                data-ng-class="{ 'later': isCurrent('stateMappable') }">
-                                <h4 class="list-group-item-heading">Mappable
-                                    <small class="badge">{{ dataset.stateMappable.d }} {{ dataset.stateMappable.t }}</small>
+                            <li
+                                data-ng-show="dataset.stateMappable"
+                                class="ds-state list-group-item"
+                                data-ng-class="{ 'later': isCurrent('stateMappable') }"
+                            >
+                                <h4 class="list-group-item-heading">
+                                    Mappable
+                                    <small class="badge"
+                                        >{{ dataset.stateMappable.d }}
+                                        {{ dataset.stateMappable.t }}</small
+                                    >
                                 </h4>
                                 <div class="btn-toolbar">
-                                    <a href="{{sipCreatorLink}}" id="nav-mapper">
-                                        <i class="fa fa-fw fa-download"></i> Download the mapping tool
+                                    <a
+                                        href="{{ sipCreatorLink }}"
+                                        id="nav-mapper"
+                                    >
+                                        <i class="fa fa-fw fa-download"></i>
+                                        Download the mapping tool
                                     </a>
                                 </div>
                             </li>
-                            <li data-ng-show="dataset.stateProcessable" class="ds-state list-group-item"
-                                data-ng-class="{ 'later': isCurrent('stateProcessable') }">
-                                <h4 class="list-group-item-heading">Processable
-                                    <small class="badge">{{ dataset.stateProcessable.d }} {{ dataset.stateProcessable.t }}</small>
+                            <li
+                                data-ng-show="dataset.stateProcessable"
+                                class="ds-state list-group-item"
+                                data-ng-class="{ 'later': isCurrent('stateProcessable') }"
+                            >
+                                <h4 class="list-group-item-heading">
+                                    Processable
+                                    <small class="badge"
+                                        >{{ dataset.stateProcessable.d }}
+                                        {{ dataset.stateProcessable.t }}</small
+                                    >
                                 </h4>
                                 <div class="btn-toolbar">
-                                    <a href data-ng-click="start('start processing')">
-                                        <i class="fa fa-fw fa-cogs"></i> <span>Process</span>
+                                    <a
+                                        href
+                                        data-ng-click="start('start processing')"
+                                    >
+                                        <i class="fa fa-fw fa-cogs"></i>
+                                        <span>Process</span>
                                     </a>
                                 </div>
                             </li>
-                            <li data-ng-show="dataset.stateIncrementalSaved && dataset.harvestIncrementalMode" class="ds-state list-group-item"
-                                data-ng-class="{ 'later': isCurrent('stateIncrementalSaved') }">
-                                <h4 class="list-group-item-heading">Incremental Saved
-                                    <small class="badge">{{ dataset.stateIncrementalSaved.d }} {{ dataset.stateIncrementalSaved.t }}</small>
+                            <li
+                                data-ng-show="dataset.stateIncrementalSaved && dataset.harvestIncrementalMode"
+                                class="ds-state list-group-item"
+                                data-ng-class="{ 'later': isCurrent('stateIncrementalSaved') }"
+                            >
+                                <h4 class="list-group-item-heading">
+                                    Incremental Saved
+                                    <small class="badge"
+                                        >{{ dataset.stateIncrementalSaved.d }}
+                                        {{
+                                            dataset.stateIncrementalSaved.t
+                                        }}</small
+                                    >
                                 </h4>
                                 <div class="btn-toolbar">
-                                    <a href data-ng-click="start('start processed analysis')">
-                                        <i class="fa fa-fw fa-bar-chart"></i> <span>Analyze</span>
+                                    <a
+                                        href
+                                        data-ng-click="start('start processed analysis')"
+                                    >
+                                        <i class="fa fa-fw fa-bar-chart"></i>
+                                        <span>Analyze</span>
                                     </a>
                                 </div>
                             </li>
                             <!-- todo add incremental mode back && !dataset.harvestIncrementalMode   -->
-                            <li data-ng-show="dataset.stateProcessed" class="ds-state list-group-item"
-                                data-ng-class="{ 'later': isCurrent('stateProcessed') }">
-                                <h4 class="list-group-item-heading">Processed
-                                    <small class="badge">{{ dataset.stateProcessed.d }} {{ dataset.stateProcessed.t }}</small>
+                            <li
+                                data-ng-show="dataset.stateProcessed"
+                                class="ds-state list-group-item"
+                                data-ng-class="{ 'later': isCurrent('stateProcessed') }"
+                            >
+                                <h4 class="list-group-item-heading">
+                                    Processed
+                                    <small class="badge"
+                                        >{{ dataset.stateProcessed.d }}
+                                        {{ dataset.stateProcessed.t }}</small
+                                    >
                                 </h4>
                                 <div class="btn-toolbar">
-                                    <a href data-ng-click="start('start processed analysis')">
-                                        <i class="fa fa-fw fa-bar-chart"></i> <span>Analyze</span>
+                                    <a
+                                        href
+                                        data-ng-click="start('start processed analysis')"
+                                    >
+                                        <i class="fa fa-fw fa-bar-chart"></i>
+                                        <span>Analyze</span>
                                     </a>
                                 </div>
                             </li>
-                            <li data-ng-show="dataset.stateAnalyzed " class="ds-state list-group-item"
-                                data-ng-class="{ 'later': isCurrent('stateAnalyzed') }">
-                                <h4 class="list-group-item-heading">Analyzed
-                                    <small class="badge">{{ dataset.stateAnalyzed.d }} {{ dataset.stateAnalyzed.t }}</small>
+                            <li
+                                data-ng-show="dataset.stateAnalyzed "
+                                class="ds-state list-group-item"
+                                data-ng-class="{ 'later': isCurrent('stateAnalyzed') }"
+                            >
+                                <h4 class="list-group-item-heading">
+                                    Analyzed
+                                    <small class="badge"
+                                        >{{ dataset.stateAnalyzed.d }}
+                                        {{ dataset.stateAnalyzed.t }}</small
+                                    >
                                 </h4>
                                 <div class="btn-toolbar">
                                     <a href data-ng-click="goToDataset()">
-                                        <i class="fa fa-fw fa-language"></i> <span>Explore</span>
+                                        <i class="fa fa-fw fa-language"></i>
+                                        <span>Explore</span>
                                     </a>
-                                    <br/>
+                                    <br />
                                     <!-- TODO: enable when process and save are folded together -->
                                     <!--<a href="{{ sparqlPath }}">-->
                                     <!--<i class="fa fa-fw fa-eye"></i>-->
@@ -245,16 +438,27 @@
                                     <!--<a href data-ng-click="goToTerms()" data-ng-if="dataset.skosField">-->
                                     <!--<i class="fa fa-fw fa-magic"></i> <span>Map vocabulary terms</span>-->
                                     <!--</a>-->
-                                    <a href data-ng-click="start('start saving')">
-                                        <i class="fa fa-fw fa-database"></i> <span>Save</span>
+                                    <a
+                                        href
+                                        data-ng-click="start('start saving')"
+                                    >
+                                        <i class="fa fa-fw fa-database"></i>
+                                        <span>Save</span>
                                     </a>
                                 </div>
                             </li>
                             <!--todo: hide this when bulk is enabled -->
-                            <li data-ng-show="dataset.stateSaved" class="ds-state list-group-item"
-                                data-ng-class="{ 'later': isCurrent('stateSaved') }">
-                                <h4 class="list-group-item-heading">Saved
-                                    <small class="badge">{{ dataset.stateSaved.d }} {{ dataset.stateSaved.t }}</small>
+                            <li
+                                data-ng-show="dataset.stateSaved"
+                                class="ds-state list-group-item"
+                                data-ng-class="{ 'later': isCurrent('stateSaved') }"
+                            >
+                                <h4 class="list-group-item-heading">
+                                    Saved
+                                    <small class="badge"
+                                        >{{ dataset.stateSaved.d }}
+                                        {{ dataset.stateSaved.t }}</small
+                                    >
                                 </h4>
                                 <div class="btn-toolbar">
                                     <div class="btn-toolbar">
@@ -262,24 +466,37 @@
                                             <i class="fa fa-fw fa-eye"></i>
                                             <span>View saved RDF</span>
                                         </a>
-                                        <br/>
-                                        <a href data-ng-click="goToTerms()" data-ng-if="dataset.skosField">
-                                            <i class="fa fa-fw fa-magic"></i> <span>Map vocabulary terms</span>
+                                        <br />
+                                        <a
+                                            href
+                                            data-ng-click="goToTerms()"
+                                            data-ng-if="dataset.skosField"
+                                        >
+                                            <i class="fa fa-fw fa-magic"></i>
+                                            <span>Map vocabulary terms</span>
                                         </a>
                                     </div>
                                 </div>
                             </li>
                         </ul>
-
-
                     </div>
                     <div class="col-md-9 dataset-forms">
                         <div data-ng-if="dataset.progress" class="ds-progress">
                             <div class="input-group">
-                                <progressbar class="form-control-feedback progress-striped" value="dataset.progress.count" max="100">{{ dataset.progress.message }}</progressbar>
+                                <progressbar
+                                    class="form-control-feedback progress-striped"
+                                    value="dataset.progress.count"
+                                    max="100"
+                                    >{{ dataset.progress.message }}</progressbar
+                                >
                                 <div class="input-group-btn">
-                                    <button class="btn btn-danger btn-xs" data-ng-click="interruptProcessing(file)" data-ng-show="dataset.progress">
-                                        <i class="fa fa-trash-o"></i> <span>Cancel</span>
+                                    <button
+                                        class="btn btn-danger btn-xs"
+                                        data-ng-click="interruptProcessing(file)"
+                                        data-ng-show="dataset.progress"
+                                    >
+                                        <i class="fa fa-trash-o"></i>
+                                        <span>Cancel</span>
                                     </button>
                                 </div>
                             </div>
@@ -287,27 +504,51 @@
 
                         <div data-ng-if="dataset.datasetErrorMessage">
                             <div class="alert alert-danger" role="alert">
-                                <button type="button" class="close" data-dismiss="alert" data-ng-click="clearError()" aria-label="Close">
-                                    <span aria-hidden="true">&times;</span></button>
-                                <i class="fa fa-exclamation-circle"></i> <span>{{dataset.datasetErrorMessage | unsafe }}</span>
-                                <hr/>
+                                <button
+                                    type="button"
+                                    class="close"
+                                    data-dismiss="alert"
+                                    data-ng-click="clearError()"
+                                    aria-label="Close"
+                                >
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                                <i class="fa fa-exclamation-circle"></i>
+                                <span>{{
+                                    dataset.datasetErrorMessage | unsafe
+                                }}</span>
+                                <hr />
                                 You must
-                                <a href data-dismiss="alert" data-ng-click="clearError()" class="alert-link">close/clear</a>
+                                <a
+                                    href
+                                    data-dismiss="alert"
+                                    data-ng-click="clearError()"
+                                    class="alert-link"
+                                    >close/clear</a
+                                >
                                 this error message to continue
                             </div>
                         </div>
 
                         <h4 data-ng-show="dataset.metadata.name">
                             <span>"{{ dataset.metadata.name | unsafe }}"</span>
-                            <span data-ng-show="dataset.metadata.dataProvider">from "{{ dataset.metadata.dataProvider }}": </span>
+                            <span data-ng-show="dataset.metadata.dataProvider"
+                                >from "{{ dataset.metadata.dataProvider }}":
+                            </span>
                         </h4>
 
                         <div class="row">
                             <div class="tabbable dataset-tabs col-md-6">
-
                                 <ul class="nav nav-pills" role="tablist">
-                                    <li ng-class="{'active':leftTabOpen === 'metadata'}">
-                                        <a href role="tab" data-ng-click="leftTabOpen = 'metadata'">Metadata</a>
+                                    <li
+                                        ng-class="{'active':leftTabOpen === 'metadata'}"
+                                    >
+                                        <a
+                                            href
+                                            role="tab"
+                                            data-ng-click="leftTabOpen = 'metadata'"
+                                            >Metadata</a
+                                        >
                                     </li>
                                     <!-- <li ng-class="{'active':leftTabOpen === 'publication'}">
                                         <a href role="tab" data-ng-click="leftTabOpen = 'publication'">Publication</a>
@@ -315,11 +556,25 @@
                                     <!--<li ng-class="{'active':leftTabOpen === 'categories'}">-->
                                     <!--<a href role="tab" data-ng-click="leftTabOpen ='categories'">Categories</a>-->
                                     <!--</li>-->
-                                    <li data-ng-class="{'active':leftTabOpen === 'harvesting'}">
-                                        <a href role="tab" data-ng-click="leftTabOpen = 'harvesting'">Harvesting</a>
+                                    <li
+                                        data-ng-class="{'active':leftTabOpen === 'harvesting'}"
+                                    >
+                                        <a
+                                            href
+                                            role="tab"
+                                            data-ng-click="leftTabOpen = 'harvesting'"
+                                            >Harvesting</a
+                                        >
                                     </li>
-                                    <li data-ng-class="{'active':leftTabOpen === 'check-links'}">
-                                        <a href role="tab" data-ng-click="leftTabOpen ='check-links'">Links</a>
+                                    <li
+                                        data-ng-class="{'active':leftTabOpen === 'check-links'}"
+                                    >
+                                        <a
+                                            href
+                                            role="tab"
+                                            data-ng-click="leftTabOpen ='check-links'"
+                                            >Links</a
+                                        >
                                     </li>
                                     <!--<li data-ng-class="{'active':leftTabOpen === 'mapping'}">-->
                                     <!--<a href role="tab" data-ng-click="leftTabOpen ='mapping'">Mapping</a>-->
@@ -329,7 +584,11 @@
                                 <div class="tab-content clearfix">
                                     <div ng-switch="leftTabOpen">
                                         <div ng-switch-when="metadata">
-                                            <div data-ng-include="'dataset-metadata-form.html'">metadata form</div>
+                                            <div
+                                                data-ng-include="'dataset-metadata-form.html'"
+                                            >
+                                                metadata form
+                                            </div>
                                         </div>
                                         <!-- <div ng-switch-when="publication">
                                             <div data-ng-include="'publication-form.html'">publication form</div>
@@ -338,62 +597,131 @@
                                         <!--<div data-ng-include="'categories-form.html'">categories form</div>-->
                                         <!--</div>-->
                                         <div ng-switch-when="check-links">
-                                            <div data-ng-include="'check-links.html'">check links</div>
+                                            <div
+                                                data-ng-include="'check-links.html'"
+                                            >
+                                                check links
+                                            </div>
                                         </div>
                                         <div ng-switch-when="harvesting">
-                                            <div data-ng-include="'harvesting-info.html'">harvesting statistics</div>
+                                            <div
+                                                data-ng-include="'harvesting-info.html'"
+                                            >
+                                                harvesting statistics
+                                            </div>
                                         </div>
                                         <div ng-switch-when="mapping">
-                                            <div data-ng-include="'mapping.html'">harvesting statistics</div>
+                                            <div
+                                                data-ng-include="'mapping.html'"
+                                            >
+                                                harvesting statistics
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
 
                             <div class="tabbable dataset-tabs col-md-6">
-
                                 <ul class="nav nav-pills" role="tablist">
-                                    <li ng-class="{'active':rightTabOpen === 'drop'}" data-ng-show="dropSupported">
-                                        <a href role="tab" data-ng-click="rightTabOpen = 'drop'">File Drop</a>
+                                    <li
+                                        ng-class="{'active':rightTabOpen === 'drop'}"
+                                        data-ng-show="dropSupported"
+                                    >
+                                        <a
+                                            href
+                                            role="tab"
+                                            data-ng-click="rightTabOpen = 'drop'"
+                                            >File Drop</a
+                                        >
                                     </li>
-                                    <li ng-class="{'active':rightTabOpen === 'harvest'}">
-                                        <a href role="tab" data-ng-click="rightTabOpen ='harvest'">Harvest</a>
+                                    <li
+                                        ng-class="{'active':rightTabOpen === 'harvest'}"
+                                    >
+                                        <a
+                                            href
+                                            role="tab"
+                                            data-ng-click="rightTabOpen ='harvest'"
+                                            >Harvest</a
+                                        >
                                     </li>
-                                    <li ng-class="{'active':rightTabOpen === 'harvest-cron'}" data-ng-show="dataset.harvestType">
-                                        <a href role="tab" data-ng-click="rightTabOpen = 'harvest-cron'">Periodic</a>
+                                    <li
+                                        ng-class="{'active':rightTabOpen === 'harvest-cron'}"
+                                        data-ng-show="dataset.harvestType"
+                                    >
+                                        <a
+                                            href
+                                            role="tab"
+                                            data-ng-click="rightTabOpen = 'harvest-cron'"
+                                            >Periodic</a
+                                        >
                                     </li>
-                                    <li ng-class="{'active':rightTabOpen === 'id-filter'}">
-                                        <a href role="tab" data-ng-click="rightTabOpen = 'id-filter'">ID Filter</a>
+                                    <li
+                                        ng-class="{'active':rightTabOpen === 'id-filter'}"
+                                    >
+                                        <a
+                                            href
+                                            role="tab"
+                                            data-ng-click="rightTabOpen = 'id-filter'"
+                                            >ID Filter</a
+                                        >
                                     </li>
-                                    <li data-ng-class="{'active':rightTabOpen==='delete'}">
-                                        <a href role="tab" data-ng-click="rightTabOpen ='delete'" class="bg-danger">
-                                            <i class="fa fa-trash fa-lg"></i>&nbsp;</a>
+                                    <li
+                                        data-ng-class="{'active':rightTabOpen==='delete'}"
+                                    >
+                                        <a
+                                            href
+                                            role="tab"
+                                            data-ng-click="rightTabOpen ='delete'"
+                                            class="bg-danger"
+                                        >
+                                            <i class="fa fa-trash fa-lg"></i
+                                            >&nbsp;</a
+                                        >
                                     </li>
                                 </ul>
 
                                 <div class="tab-content clearfix">
                                     <div ng-switch="rightTabOpen">
                                         <div ng-switch-when="drop">
-                                            <div data-ng-include="'drop-file-dataset.html'">drop file</div>
+                                            <div
+                                                data-ng-include="'drop-file-dataset.html'"
+                                            >
+                                                drop file
+                                            </div>
                                         </div>
                                         <div ng-switch-when="harvest">
-                                            <div data-ng-include="'harvest-form.html'">harvest form</div>
+                                            <div
+                                                data-ng-include="'harvest-form.html'"
+                                            >
+                                                harvest form
+                                            </div>
                                         </div>
                                         <div ng-switch-when="harvest-cron">
-                                            <div data-ng-include="'harvest-cron-form.html'">harvest cron form</div>
+                                            <div
+                                                data-ng-include="'harvest-cron-form.html'"
+                                            >
+                                                harvest cron form
+                                            </div>
                                         </div>
                                         <div ng-switch-when="id-filter">
-                                            <div data-ng-include="'id-filter-form.html'">id filter form</div>
+                                            <div
+                                                data-ng-include="'id-filter-form.html'"
+                                            >
+                                                id filter form
+                                            </div>
                                         </div>
                                         <div ng-switch-when="delete">
-                                            <div data-ng-include="'dataset-delete.html'">deletion form</div>
+                                            <div
+                                                data-ng-include="'dataset-delete.html'"
+                                            >
+                                                deletion form
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-
                 </div>
             </div>
         </div>
@@ -445,7 +773,13 @@
             <div class="form-group">
                 <label class="col-sm-3 control-label" for="meta_edm_type">Type</label>
                 <div class="col-sm-9">
-                    <input id="meta_edm_type" name="meta_edm_type" required class="form-control" data-ng-model="dataset.edit.edmType"/>
+                <input id="meta_edm_type" name="meta_edm_type" required class="form-control" data-ng-model="dataset.edit.edmType"/>
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="col-sm-3 control-label" for="meta_dataset_tags">Tags</label>
+            <div class="col-sm-9">
+                <input id="meta_dataset_tags" name="meta_dataset_tags" required class="form-control" data-ng-model="dataset.edit.datasetTags"/>
                 </div>
             </div>
             <div class="form-group" ng-class="{'has-error' : metadataform.meta_rights.$invalid, 'has-success' : metadataform.meta_rights.$valid && !metadataform.meta_rights.$pristine }">
@@ -741,8 +1075,7 @@
     </form>
 </script>
 
-<script type="text/ng-template" id="downloads.html">
-</script>
+<script type="text/ng-template" id="downloads.html"></script>
 
 <script type="text/ng-template" id="check-links.html">
     <ul class="list-group">
@@ -799,31 +1132,31 @@
 <!--</script>-->
 
 <script type="text/ng-template" id="harvesting-info.html">
-    <!-- TODO: hide if no data available -->
-    <ul class="list-group">
-        <li class="list-group-item"> record definition: {{ dataset.datasetMapToPrefix }} </li>
+      <!-- TODO: hide if no data available -->
+      <ul class="list-group">
+          <li class="list-group-item"> record definition: {{ dataset.datasetMapToPrefix }} </li>
+      </ul>
+    <ul  class="list-group">
+      <li class="list-group-item">
+        <!-- If last full harvest date -->
+        Last full harvest date: {{ dataset.lastFullHarvestTime }}
+      </li>
+      <li class="list-group-item">Valid records: {{ dataset.processedValid }}</li>
+      <li class="list-group-item">Invalid records: {{ dataset.processedInvalid }}</li>
     </ul>
-  <ul  class="list-group">
-    <li class="list-group-item">
-      <!-- If last full harvest date -->
-      Last full harvest date: {{ dataset.lastFullHarvestTime }}
-    </li>
-    <li class="list-group-item">Valid records: {{ dataset.processedValid }}</li>
-    <li class="list-group-item">Invalid records: {{ dataset.processedInvalid }}</li>
-  </ul>
-  <ul  class="list-group">
-    <li class="list-group-item">  <!-- If last incremental harvest date -->
-      In scheduled mode: {{ dataset.harvestIncrementalMode }}</li>
-    <li class="list-group-item">Last scheduled harvest date: {{ dataset.lastIncrementalHarvestTime }}</li>
-    <li class="list-group-item">Valid records: {{ dataset.processedIncrementalValid }}</li>
-    <li class="list-group-item">Invalid records: {{ dataset.processedIncrementalInvalid }}</li>
-  </ul>
-  <ul  class="list-group">
-    <li class="list-group-item">  <a ng-href="" data-ng-click="showLastSourcedPage()">Last harvested records</a></li>
-    <li class="list-group-item"><a ng-href="" data-ng-click="showHarvestingLog()">Harvesting log</a></li>
-    <li class="list-group-item"><a ng-href="" data-ng-click="showLastProcessedPage()">Last processed records</a></li>
-    <li class="list-group-item"><a ng-href="" data-ng-click="showInvalidRecordsPage()">Last processing errors</a></li>
-  </ul>
+    <ul  class="list-group">
+      <li class="list-group-item">  <!-- If last incremental harvest date -->
+        In scheduled mode: {{ dataset.harvestIncrementalMode }}</li>
+      <li class="list-group-item">Last scheduled harvest date: {{ dataset.lastIncrementalHarvestTime }}</li>
+      <li class="list-group-item">Valid records: {{ dataset.processedIncrementalValid }}</li>
+      <li class="list-group-item">Invalid records: {{ dataset.processedIncrementalInvalid }}</li>
+    </ul>
+    <ul  class="list-group">
+      <li class="list-group-item">  <a ng-href="" data-ng-click="showLastSourcedPage()">Last harvested records</a></li>
+      <li class="list-group-item"><a ng-href="" data-ng-click="showHarvestingLog()">Harvesting log</a></li>
+      <li class="list-group-item"><a ng-href="" data-ng-click="showLastProcessedPage()">Last processed records</a></li>
+      <li class="list-group-item"><a ng-href="" data-ng-click="showInvalidRecordsPage()">Last processing errors</a></li>
+    </ul>
 </script>
 
 <script type="text/ng-template" id="dataset-delete.html">
@@ -877,7 +1210,6 @@
     </form>
 </script>
 
-
 <script type="text/ng-template" id="new-dataset.html">
     <div class="aside-backdrop am-fade" style=""></div>
     <div class="aside right animated fadeInRightBig">
@@ -921,6 +1253,12 @@
     </div>
 </script>
 
-<div class="fade" ng-file-drop-available="setDropSupported()" ng-show="!dropSupported">
-    <h4>HTML5 Drop File is not supported! You need an HTML5 compliant browser.</h4>
+<div
+    class="fade"
+    ng-file-drop-available="setDropSupported()"
+    ng-show="!dropSupported"
+>
+    <h4>
+        HTML5 Drop File is not supported! You need an HTML5 compliant browser.
+    </h4>
 </div>

--- a/public/templates/dataset.html
+++ b/public/templates/dataset.html
@@ -1,50 +1,88 @@
 <div class="page-header">
     <!-- page location, org -->
     <div class="meta">
-        <div class="page">
-            Dataset: {{spec}}
-        </div>
+        <div class="page">Dataset: {{ spec }}</div>
         <div class="organization">
             <span class="fa fa-institution"></span>
             <span>{{ orgId }}</span>
             <span class="file-path-info">
-                <span class="file-name">{{spec}}</span><span class="file-path">{{activePath}}</span>
+                <span class="file-name">{{ spec }}</span
+                ><span class="file-path">{{ activePath }}</span>
             </span>
         </div>
-
     </div>
     <!-- page specifiction actions/tools -->
     <div class="actions">
-        <button ng-click="sidebarNav('dataset-list', spec)" class="btn btn-default">
+        <button
+            ng-click="sidebarNav('dataset-list', spec)"
+            class="btn btn-default"
+        >
             <i class="fa fa-cog"></i> go back to dataset
         </button>
     </div>
-
 </div>
 
 <div class="row" ng-show="tree">
-
     <div class="col-sm-5">
         <div class="widget widget-schema">
             <div class="widget-header">
                 <span>Schema</span>
                 <span class="dropdown pull-right">
-                    <a href class="btn btn-success btn-sm" data-ng-click="confirmUniqueId()" data-ng-show="uniqueIdChosen">
-                        <i class="fa fa-check-circle"></i> <span> Confirm Unique Id</span>
+                    <a
+                        href
+                        class="btn btn-success btn-sm"
+                        data-ng-click="confirmUniqueId()"
+                        data-ng-show="uniqueIdChosen"
+                    >
+                        <i class="fa fa-check-circle"></i>
+                        <span> Confirm Unique Id</span>
                     </a>
-                    <a href class="btn btn-warning btn-sm" data-ng-click="selectPMHRecordRoot()" data-ng-show="uniqueIdChosen">
-                        <i class="fa fa-check-circle"></i> <span> Set Metadata Root</span>
+                    <a
+                        href
+                        class="btn btn-warning btn-sm"
+                        data-ng-click="selectPMHRecordRoot()"
+                        data-ng-show="uniqueIdChosen"
+                    >
+                        <i class="fa fa-check-circle"></i>
+                        <span> Set Metadata Root</span>
                     </a>
-                    <a href class="btn btn-default btn-sm" data-toggle="dropdown">
-                        <i class="fa fa-eye"></i>&nbsp;<span class="caret"></span>
+                    <a
+                        href
+                        class="btn btn-default btn-sm"
+                        data-toggle="dropdown"
+                    >
+                        <i class="fa fa-eye"></i>&nbsp;<span
+                            class="caret"
+                        ></span>
                     </a>
                     <ul class="dropdown-menu dropdown-menu-right" role="menu">
-                        <li><a data-ng-href="{{ apiPrefix }}/{{ spec }}/tree" target="_blank">Tree</a></li>
-                        <li><a data-ng-href="{{ apiPrefix }}/{{ spec }}" target="_blank">Paths</a></li>
+                        <li>
+                            <a
+                                data-ng-href="{{ apiPrefix }}/{{ spec }}/tree"
+                                target="_blank"
+                                >Tree</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                data-ng-href="{{ apiPrefix }}/{{ spec }}"
+                                target="_blank"
+                                >Paths</a
+                            >
+                        </li>
                     </ul>
                 </span>
             </div>
-            <div class="vertical-scroll list-group" data-scrollable id="schema-tree" data-offset="160" data-ng-controller="TreeCtrl" data-ng-include="'node.html'">Node list</div>
+            <div
+                class="vertical-scroll list-group"
+                data-scrollable
+                id="schema-tree"
+                data-offset="160"
+                data-ng-controller="TreeCtrl"
+                data-ng-include="'node.html'"
+            >
+                Node list
+            </div>
         </div>
     </div>
 
@@ -55,62 +93,125 @@
     </div>
 
     <div class="col-sm-7" data-ng-if="selectedNode">
-
         <div class="widget">
             <div class="widget-header clearfix">
-
                 <ul class="nav nav-tabs pull-left">
                     <li data-ng-class="{ active: activeView == 'histogram' }">
-                        <a href="" data-ng-click="fetchHistogram()">Histogram</a>
+                        <a href="" data-ng-click="fetchHistogram()"
+                            >Histogram</a
+                        >
                     </li>
                     <li data-ng-class="{ active: activeView == 'sample' }">
                         <a href="" data-ng-click="fetchSample()">Samples</a>
                     </li>
                 </ul>
                 <ul class="list-inline pull-right">
-                    <li data-ng-show="rawAnalyzedState && activeView == 'histogram' && histogramUniqueEnough">
-                        <a href class="btn btn-warning btn-sm" data-ng-click="proposeUniqueIdNode(selectedNode)" data-ng-disabled="uniqueIdNode == selectedNode">
-                            <i class="fa fa-check-circle"></i> <span> Use as Unique Element</span>
+                    <li
+                        data-ng-show="rawAnalyzedState && activeView == 'histogram' && histogramUniqueEnough"
+                    >
+                        <a
+                            href
+                            class="btn btn-warning btn-sm"
+                            data-ng-click="proposeUniqueIdNode(selectedNode)"
+                            data-ng-disabled="uniqueIdNode == selectedNode"
+                        >
+                            <i class="fa fa-check-circle"></i>
+                            <span> Use as Unique Element</span>
                         </a>
                     </li>
 
                     <li>
-                        <a href class="btn btn-default btn-sm" data-toggle="dropdown">
-                            <i class="fa fa-eye"></i>&nbsp;<span class="caret"></span>
+                        <a
+                            href
+                            class="btn btn-default btn-sm"
+                            data-toggle="dropdown"
+                        >
+                            <i class="fa fa-eye"></i>&nbsp;<span
+                                class="caret"
+                            ></span>
                         </a>
-                        <ul class="dropdown-menu dropdown-menu-right" role="menu">
-                            <li><a ng-href="{{apiPathUnique}}" target="_blank">All Values</a></li>
-                            <li><a ng-href="{{apiPathHistogram}}" target="_blank">Full Histogram</a></li>
+                        <ul
+                            class="dropdown-menu dropdown-menu-right"
+                            role="menu"
+                        >
+                            <li>
+                                <a ng-href="{{ apiPathUnique }}" target="_blank"
+                                    >All Values</a
+                                >
+                            </li>
+                            <li>
+                                <a
+                                    ng-href="{{ apiPathHistogram }}"
+                                    target="_blank"
+                                    >Full Histogram</a
+                                >
+                            </li>
                         </ul>
                     </li>
                 </ul>
             </div>
 
-            <div class="vertical-scroll" data-scrollable id="sample-list" data-offset="200" ng-show="sample">
+            <div
+                class="vertical-scroll"
+                data-scrollable
+                id="sample-list"
+                data-offset="200"
+                ng-show="sample"
+            >
                 <ul class="list-group">
-                    <li data-ng-repeat="value in sample.sample | filter:filterText" class="list-group-item">
+                    <li
+                        data-ng-repeat="value in sample.sample | filter:filterText"
+                        class="list-group-item"
+                    >
                         {{ value }}
                     </li>
                 </ul>
             </div>
 
-            <div class="vertical-scroll" data-scrollable id="histogram-list" data-offset="210" ng-show="histogram">
+            <div
+                class="vertical-scroll"
+                data-scrollable
+                id="histogram-list"
+                data-offset="210"
+                ng-show="histogram"
+            >
                 <ul class="list-group">
-                    <li data-ng-show="!histogramSkosField" class="list-group-item">
+                    <li
+                        data-ng-show="!histogramSkosField"
+                        class="list-group-item"
+                    >
                         <!-- Skosify button -->
-                        <a href data-ng-click="toggleSkosifiedField(histogram.uri, histogram.tag, true)" class="btn btn-success btn-block btn-xs">
+                        <a
+                            href
+                            data-ng-click="toggleSkosifiedField(histogram.uri, histogram.tag, true)"
+                            class="btn btn-success btn-block btn-xs"
+                        >
                             Skosify ({{ histogram.tag }})
                         </a>
                     </li>
-                    <li data-ng-show="analyzedState && histogramSkosField && activeView == 'histogram'" class="list-group-item">
-                        <div href data-ng-click="toggleSkosifiedField(histogram.uri, histogram.tag, false)" class="btn btn-success btn-block btn-xs">
+                    <li
+                        data-ng-show="analyzedState && histogramSkosField && activeView == 'histogram'"
+                        class="list-group-item"
+                    >
+                        <div
+                            href
+                            data-ng-click="toggleSkosifiedField(histogram.uri, histogram.tag, false)"
+                            class="btn btn-success btn-block btn-xs"
+                        >
                             Skosified ({{ histogram.tag }}) Press to revert.
                         </div>
                     </li>
-                    <li data-ng-repeat="count in histogram.histogram | filter:filterText"
-                        class="list-group-item clearfix">
+                    <li
+                        data-ng-repeat="count in histogram.histogram | filter:filterText"
+                        class="list-group-item clearfix"
+                    >
                         <span class="node-content">{{ count[1] }}</span>
-                        <span class="node-stats badge">{{ count[0] }} <span class="small">({{ count[2] | number:0 }}%)</span></span>
+                        <span class="node-stats badge"
+                            >{{ count[0] }}
+                            <span class="small"
+                                >({{ count[2] | number: 0 }}%)</span
+                            ></span
+                        >
                     </li>
                 </ul>
             </div>
@@ -118,64 +219,75 @@
             <div class="widget-footer">
                 <div class="sub-controls">
                     <span data-ng-if="histogram">
-                        <span class="btn count-btn">( {{histogram.entries}} / {{histogram.uniqueCount}} )</span>
-                        <button class="btn btn-default" data-ng-class="{ disabled: !isMoreHistogram() }"
-                            data-ng-click="moreHistogram();scrollTo({element: '#histogram-list', direction: 'down'})">
+                        <span class="btn count-btn"
+                            >( {{ histogram.entries }} /
+                            {{ histogram.uniqueCount }} )</span
+                        >
+                        <button
+                            class="btn btn-default"
+                            data-ng-class="{ disabled: !isMoreHistogram() }"
+                            data-ng-click="moreHistogram();scrollTo({element: '#histogram-list', direction: 'down'})"
+                        >
                             More histogram entries
                         </button>
                         <span data-ng-if="histogram.uniqueCount > 30">
-                            <button class="btn btn-default"
-                                data-ng-click="scrollTo({element: '#histogram-list', direction: 'up'})">
+                            <button
+                                class="btn btn-default"
+                                data-ng-click="scrollTo({element: '#histogram-list', direction: 'up'})"
+                            >
                                 <i class="fa fa-hand-o-up"></i>&#160;
                             </button>
-                            <button class="btn btn-default"
-                                data-ng-click="scrollTo({element: '#histogram-list', direction: 'down'})">
+                            <button
+                                class="btn btn-default"
+                                data-ng-click="scrollTo({element: '#histogram-list', direction: 'down'})"
+                            >
                                 <i class="fa fa-hand-o-down"></i>&nbsp;
                             </button>
                         </span>
                     </span>
                     <span data-ng-if="sample">
-                        <button class="btn btn-primary btn-sm" data-ng-show="isMoreSample()"
-                            data-ng-click="moreSample();scrollTo({element: '#sample-list', direction: 'down'})">
+                        <button
+                            class="btn btn-primary btn-sm"
+                            data-ng-show="isMoreSample()"
+                            data-ng-click="moreSample();scrollTo({element: '#sample-list', direction: 'down'})"
+                        >
                             <i class="fa fa-plus-circle"></i> More samples
                         </button>
                     </span>
                 </div>
             </div>
         </div>
-
     </div>
 </div>
 
 <script type="text/ng-template" id="node.html">
-        <div class="node" data-ng-class="{ 'chosen': node == selectedNode, 'active': node.lengths.length != 0 }" data-ng-click="selectNode(node, $event)" class="outer-node">
-            <span data-ng-show="!node.lengths.length > 0" data-ng-click="node.collapsed = !node.collapsed">
-                <i data-ng-class="{ 'fa, fa-folder-open-o' : !node.collapsed, 'fa, fa-folder-o': node.collapsed}" class="fa pointer"></i>
+    <div class="node" data-ng-class="{ 'chosen': node == selectedNode, 'active': node.lengths.length != 0 }" data-ng-click="selectNode(node, $event)" class="outer-node">
+        <span data-ng-show="!node.lengths.length > 0" data-ng-click="node.collapsed = !node.collapsed">
+            <i data-ng-class="{ 'fa, fa-folder-open-o' : !node.collapsed, 'fa, fa-folder-o': node.collapsed}" class="fa pointer"></i>
+        </span>
+        <span>{{ node.tag }}</span>
+        <span class="pull-right">
+            <span data-ng-if="node == recordRootNode" class="badge badge-record-root">
+                Record Root
             </span>
-            <span>{{ node.tag }}</span>
-            <span class="pull-right">
-                <span data-ng-if="node == recordRootNode" class="badge badge-record-root">
-                    Record Root
-                </span>
-                <span data-ng-if="node == uniqueIdNode" class="badge badge-unique">
-                    Unique Id
-                </span>
-
-                <!--todo: find a way to show which fields are skosified-->
-                <!--<span data-ng-show="analyzedState">-->
-                    <!--<div class="badge badge-warning">{{ node.tag }}</div>-->
-                <!--</span>-->
-
-                <span class="badge badge-info">
-                    {{ node.count }}
-                </span>
+            <span data-ng-if="node == uniqueIdNode" class="badge badge-unique">
+                Unique Id
             </span>
-        </div>
 
-        <div data-ng-if="node.kids && !node.collapsed" class="inner-node">
-            <div data-ng-repeat="(nodeIndex, node) in node.kids">
-                <div data-ng-include="'node.html'" class="inner-node">node</div>
-            </div>
-        </div>
+            <!--todo: find a way to show which fields are skosified-->
+            <!--<span data-ng-show="analyzedState">-->
+                <!--<div class="badge badge-warning">{{ node.tag }}</div>-->
+            <!--</span>-->
 
+            <span class="badge badge-info">
+                {{ node.count }}
+            </span>
+        </span>
+    </div>
+
+    <div data-ng-if="node.kids && !node.collapsed" class="inner-node">
+        <div data-ng-repeat="(nodeIndex, node) in node.kids">
+            <div data-ng-include="'node.html'" class="inner-node">node</div>
+        </div>
+    </div>
 </script>


### PR DESCRIPTION
The default subject extraction is based on the first resource that is part of the graph. This should be taken into account when creating Record Definitions.

Tags from the interface are submitted to the hub3 bulk indexing interface. This can be used to trigger custom behavior. For example, `fragmentsOnly` will only index a dataset in the LDF index.