### PR TITLE
update sip-core and version number

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "log4j-over-slf4j" % "1.7.21",
   "org.easybatch" % "easybatch-apache-commons-csv" % "3.0.0",
   "com.typesafe.play" %% "play-mailer" % "5.0.0",
-  "eu.delving" % "sip-core" % "1.2.6",
+  "eu.delving" % "sip-core" % "1.2.8",
   "de.threedimensions" %% "metrics-play" % "2.5.13",
   "com.getsentry.raven" % "raven-logback" % "7.6.0" % "runtime",
   "nl.grons" %% "metrics-scala" % "3.5.5_a2.3",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.7"
+version in ThisBuild := "0.6.8"


### PR DESCRIPTION
Sip-core 1.2.8 has RDF validation build in when bulk processing records. These errors will now also be shown when processing a dataset in narthex.