### PR TITLE
Feature/incremental harvest semaphore release

### DIFF
--- a/app/dataset/DatasetActor.scala
+++ b/app/dataset/DatasetActor.scala
@@ -457,6 +457,7 @@ class DatasetActor(val datasetContext: DatasetContext,
       def processIncremental(fileOpt: Option[File],
                              noRecordsMatch: Boolean,
                              mod: Option[DateTime]) = {
+        orgContext.semaphore.release(dsInfo.spec)
         noRecordsMatch match {
           case true =>
             Logger.debug(

--- a/app/harvest/Harvester.scala
+++ b/app/harvest/Harvester.scala
@@ -80,8 +80,9 @@ class Harvester(timeout: Long, datasetContext: DatasetContext, wsApi: WSAPI,
   }
 
   def finish(strategy: HarvestStrategy, errorOpt: Option[String]) = {
+
     zipOutputOpt.foreach(_.close())
-    log.info(s"Finished $strategy harvest error=$errorOpt")
+    log.info(s"Finished $strategy harvest error=$errorOpt for dataset $datasetContext")
     errorOpt match {
       case Some("noRecordsMatch") =>
         log.info(s"Finished incremental harvest with noRecordsMatch")

--- a/app/harvest/PeriodicHarvest.scala
+++ b/app/harvest/PeriodicHarvest.scala
@@ -54,7 +54,7 @@ class PeriodicHarvest(orgContext: OrgContext) extends Actor {
             sortWith((s, t) => s.getPreviousHarvestTime().isBefore(t.getPreviousHarvestTime())).
             foreach { listedInfo =>
               val harvestCron = listedInfo.currentHarvestCron
-              log.info(s"scheduled ds: ${listedInfo.spec} ${listedInfo.currentHarvestCron.previous.toString()}")
+              log.info(s"scheduled ds: ${listedInfo.spec} ${listedInfo.currentHarvestCron.previous.toString()} (time to work: ${harvestCron.timeToWork})")
               if (harvestCron.timeToWork) withDsInfo(listedInfo.spec, orgContext) { info => // the cached version
                 if (orgContext.semaphore.tryAcquire(info.spec)) {
                   log.info(s"Time to work on $info: $harvestCron")

--- a/app/organization/Semaphore.scala
+++ b/app/organization/Semaphore.scala
@@ -1,12 +1,18 @@
 package organization
 
 import java.util.concurrent.ConcurrentHashMap
+import play.api.Logger
 
 class Semaphore (val permits: Int) {
+
+  val logger: Logger = Logger(this.getClass())
 
   private val semaphores = new ConcurrentHashMap[String, String]()
 
   def tryAcquire(spec: String): Boolean = {
+    if ( semaphores.containsKey(spec) ) {
+      logger.info(s"semaphore for $spec is still active or has not been released")
+    }
     if (semaphores.size() < permits && !semaphores.containsKey(spec)) {
       semaphores.put(spec, "")
       true
@@ -17,7 +23,10 @@ class Semaphore (val permits: Int) {
 
   def isActive(spec: String): Boolean = semaphores.containsKey(spec)
 
-  def release(spec: String) = semaphores.remove(spec)
+  def release(spec: String) = {
+    logger.info(s"releasing semaphore for $spec")
+    semaphores.remove(spec)
+  }
 
   def availablePermits(): Int = {
     permits - semaphores.size()

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.9"
+version in ThisBuild := "0.6.10"


### PR DESCRIPTION
The semaphore was not realesed on incremental processing when noRecordsMatch. This meant that only the first 3 in the queue would be processed and the remainder was stuck until a restart.

