### PR TITLE
feat(templates): add spinner to indicate activity to dataset list

### DIFF
--- a/public/templates/dataset-list.html
+++ b/public/templates/dataset-list.html
@@ -2,9 +2,7 @@
 <div class="page-header no-margin">
     <!-- page location, org -->
     <div class="meta">
-        <div class="page">
-            Datasets
-        </div>
+        <div class="page">Datasets</div>
         <div class="organization">
             <span class="fa fa-institution"></span>
             <span>{{ orgId }}</span>
@@ -144,9 +142,13 @@
                             data-ng-class="{ 'closed': !expanded, 'open': expanded }"
                         >
                             <td class="spec">
-                                <span class="spec-field">{{
-                                    dataset.datasetSpec
-                                }}</span>
+                                <span class="spec-field"
+                                    >{{ dataset.datasetSpec }}
+                                    <i
+                                        data-ng-show="dataset.progress"
+                                        class="fa fa-spinner fa-pulse fa-1x fa-fw"
+                                    ></i>
+                                </span>
                             </td>
                             <td class="name">
                                 <span
@@ -158,9 +160,7 @@
                             <td class="error">
                                 <span
                                     data-ng-if="dataset.harvestIncrementalMode == 'true'"
-                                    >{{
-                                        dataset.processedIncrementalInvalid
-                                    }}
+                                    >{{ dataset.processedIncrementalInvalid }}
                                     (inc)</span
                                 >
                                 <span
@@ -171,9 +171,7 @@
                             <td class="valid">
                                 <span
                                     data-ng-if="dataset.harvestIncrementalMode == 'true'"
-                                    >{{
-                                        dataset.processedIncrementalValid
-                                    }}
+                                    >{{ dataset.processedIncrementalValid }}
                                     (inc)</span
                                 >
                                 <span
@@ -239,10 +237,8 @@
                                 </span>
                             </td>
                             <td class="date-time">
-                                {{
-                                    dataset.stateCurrent.date
-                                        | date: 'yyyy/MM/dd HH:mm'
-                                }}
+                                {{ dataset.stateCurrent.date | date: 'yyyy/MM/dd
+                                HH:mm' }}
                             </td>
                         </tr>
                     </tbody>
@@ -263,8 +259,8 @@
                                 <h4 class="list-group-item-heading">
                                     Raw
                                     <small class="badge"
-                                        >{{ dataset.stateRaw.d }}
-                                        {{ dataset.stateRaw.t }}</small
+                                        >{{ dataset.stateRaw.d }} {{
+                                        dataset.stateRaw.t }}</small
                                     >
                                 </h4>
                                 <div class="btn-toolbar">
@@ -285,11 +281,9 @@
                                 <h4 class="list-group-item-heading">
                                     Raw Analyzed
                                     <small class="badge"
-                                        >{{ dataset.stateRawAnalyzed.d }}
-                                        {{
-                                            dataset.stateRawAnalyzed.t
-                                                | date: 'HH:mm'
-                                        }}</small
+                                        >{{ dataset.stateRawAnalyzed.d }} {{
+                                        dataset.stateRawAnalyzed.t | date:
+                                        'HH:mm' }}</small
                                     >
                                 </h4>
                                 <div class="btn-toolbar">
@@ -307,8 +301,8 @@
                                 <h4 class="list-group-item-heading">
                                     Sourced
                                     <small class="badge"
-                                        >{{ dataset.stateSourced.d }}
-                                        {{ dataset.stateSourced.t }}</small
+                                        >{{ dataset.stateSourced.d }} {{
+                                        dataset.stateSourced.t }}</small
                                     >
                                 </h4>
                                 <div class="btn-toolbar">
@@ -329,8 +323,8 @@
                                 <h4 class="list-group-item-heading">
                                     Mappable
                                     <small class="badge"
-                                        >{{ dataset.stateMappable.d }}
-                                        {{ dataset.stateMappable.t }}</small
+                                        >{{ dataset.stateMappable.d }} {{
+                                        dataset.stateMappable.t }}</small
                                     >
                                 </h4>
                                 <div class="btn-toolbar">
@@ -351,8 +345,8 @@
                                 <h4 class="list-group-item-heading">
                                     Processable
                                     <small class="badge"
-                                        >{{ dataset.stateProcessable.d }}
-                                        {{ dataset.stateProcessable.t }}</small
+                                        >{{ dataset.stateProcessable.d }} {{
+                                        dataset.stateProcessable.t }}</small
                                     >
                                 </h4>
                                 <div class="btn-toolbar">
@@ -374,8 +368,7 @@
                                     Incremental Saved
                                     <small class="badge"
                                         >{{ dataset.stateIncrementalSaved.d }}
-                                        {{
-                                            dataset.stateIncrementalSaved.t
+                                        {{ dataset.stateIncrementalSaved.t
                                         }}</small
                                     >
                                 </h4>
@@ -398,8 +391,8 @@
                                 <h4 class="list-group-item-heading">
                                     Processed
                                     <small class="badge"
-                                        >{{ dataset.stateProcessed.d }}
-                                        {{ dataset.stateProcessed.t }}</small
+                                        >{{ dataset.stateProcessed.d }} {{
+                                        dataset.stateProcessed.t }}</small
                                     >
                                 </h4>
                                 <div class="btn-toolbar">
@@ -420,8 +413,8 @@
                                 <h4 class="list-group-item-heading">
                                     Analyzed
                                     <small class="badge"
-                                        >{{ dataset.stateAnalyzed.d }}
-                                        {{ dataset.stateAnalyzed.t }}</small
+                                        >{{ dataset.stateAnalyzed.d }} {{
+                                        dataset.stateAnalyzed.t }}</small
                                     >
                                 </h4>
                                 <div class="btn-toolbar">
@@ -456,8 +449,8 @@
                                 <h4 class="list-group-item-heading">
                                     Saved
                                     <small class="badge"
-                                        >{{ dataset.stateSaved.d }}
-                                        {{ dataset.stateSaved.t }}</small
+                                        >{{ dataset.stateSaved.d }} {{
+                                        dataset.stateSaved.t }}</small
                                     >
                                 </h4>
                                 <div class="btn-toolbar">
@@ -514,9 +507,10 @@
                                     <span aria-hidden="true">&times;</span>
                                 </button>
                                 <i class="fa fa-exclamation-circle"></i>
-                                <span>{{
-                                    dataset.datasetErrorMessage | unsafe
-                                }}</span>
+                                <span
+                                    >{{ dataset.datasetErrorMessage | unsafe
+                                    }}</span
+                                >
                                 <hr />
                                 You must
                                 <a


### PR DESCRIPTION
Currently, it is not possible to see which datasets are active from the dataset list view. Next to the dataset spec you can now see a spinner when the dataset is active.