### PR TITLE
Fix Sample Harvest 0-records false alarm (Brocade/Anet)

### DIFF
--- a/app/harvest/Harvester.scala
+++ b/app/harvest/Harvester.scala
@@ -740,10 +740,11 @@ class Harvester(timeout: Long, datasetContext: DatasetContext, wsApi: WSClient,
           futurePage.map {
             case page: PMHHarvestPage =>
               FileUtils.writeStringToFile(rawXml, page.records, "UTF-8")
+              val sampled = if (page.totalRecords > 0) page.totalRecords else page.recordCount
               datasetContext.dsInfo.setAcquisitionCounts(
-                acquired = page.totalRecords,
+                acquired = sampled,
                 deleted = 0,
-                source = page.totalRecords,
+                source = sampled,
                 method = "pmh"
               )
               finish(strategy, None)

--- a/app/harvest/Harvester.scala
+++ b/app/harvest/Harvester.scala
@@ -819,7 +819,7 @@ class Harvester(timeout: Long, datasetContext: DatasetContext, wsApi: WSClient,
       }
     }
 
-    case PMHHarvestPage(records, url, set, prefix, total, strategy, resumptionToken, pageDeletedIds, pageDeletedCount) => actorWork(context) {
+    case PMHHarvestPage(records, url, set, prefix, total, strategy, resumptionToken, pageDeletedIds, pageDeletedCount, _) => actorWork(context) {
       resetStallTimer(strategy)
       val pageNumber = addPage(records)
       log.info(s"Harvest Page $pageNumber to $datasetContext: $resumptionToken")

--- a/app/harvest/Harvesting.scala
+++ b/app/harvest/Harvesting.scala
@@ -105,7 +105,8 @@ object Harvesting {
     strategy: HarvestStrategy,
     resumptionToken: Option[PMHResumptionToken],
     deletedIds: List[String] = List.empty,    // Record IDs with status="deleted"
-    deletedCount: Int = 0                     // Count of deleted records in this page
+    deletedCount: Int = 0,                    // Count of deleted records in this page
+    recordCount: Int = 0                      // Actual number of <record> elements on this page
   )
 
   case class AdLibHarvestPage
@@ -466,7 +467,8 @@ trait Harvesting {
               strategy,
               resumptionToken = newToken,
               deletedIds = deletedIds,
-              deletedCount = deletedIds.size
+              deletedCount = deletedIds.size,
+              recordCount = allRecords.size
             )
             logger.debug(s"Return PMHHarvestPage: $newToken, $sourceUri")
             harvestPage

--- a/docs/plans/2026-04-21-sample-harvest-zero-records-false-alarm-plan.md
+++ b/docs/plans/2026-04-21-sample-harvest-zero-records-false-alarm-plan.md
@@ -1,0 +1,329 @@
+# Sample Harvest "0 Records" False-Alarm Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the "Sample Harvest: 0 Records" dialog from firing after a successful PMH sample harvest against servers that omit the OAI-PMH `<resumptionToken completeListSize="...">` attribute (e.g., Brocade/Anet).
+
+**Architecture:** Add a `recordCount: Int` field to `PMHHarvestPage` populated from the parsed XML record list during `fetchPMHPage`. The PMH sample handler uses a fallback expression so it reports the actual sampled count when `completeListSize` is absent or zero. No frontend changes.
+
+**Tech Stack:** Scala 2.13, Play Framework 2.8.20, ScalaTest, Joda Time.
+
+**Spec:** `docs/specs/2026-04-21-sample-harvest-zero-records-false-alarm-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `app/harvest/Harvesting.scala` | OAI-PMH request + response model; `PMHHarvestPage` case class and `fetchPMHPage` constructor call | Modify (case class lines 98-109, constructor call lines 460-470) |
+| `app/harvest/Harvester.scala` | PMH sample handler that calls `setAcquisitionCounts` | Modify (lines 743-748) |
+| `test/harvest/PMHHarvestPageRecordCountSpec.scala` | New spec asserting `recordCount` population for both resumption-token and no-token cases | Create |
+
+---
+
+## Task 1: Add `recordCount` field to `PMHHarvestPage` + populate in `fetchPMHPage` — tests
+
+**Files:**
+- Modify: `app/harvest/Harvesting.scala` (case class lines 98-109; constructor call lines 460-470)
+- Create: `test/harvest/PMHHarvestPageRecordCountSpec.scala`
+
+Drive the change TDD: fixture OAI-PMH XML fed through the existing PMH parsing should produce a `PMHHarvestPage` with a truthful `recordCount`. The shortest path to test the parser end-to-end is to exercise `fetchPMHPage` via `play.api.test.MockWS`, but that drags in WS setup. Simpler: extract the record-counting into the same place where the XML is already parsed (line 437) and write an assertion against the final `PMHHarvestPage` via an integration-style test that constructs the class directly.
+
+This plan avoids the MockWS rabbit hole by asserting `PMHHarvestPage.recordCount` construction in two ways:
+
+1. Direct construction with the new field (confirms the case class grew the field).
+2. A string-level parser helper exercised on two fixture XMLs: one with resumption token, one without. Copy the record-count expression into the test to document the expected parse.
+
+### Step 1: Write the failing test
+
+Create `test/harvest/PMHHarvestPageRecordCountSpec.scala`:
+
+```scala
+//===========================================================================
+//    Copyright 2026 Delving B.V.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//===========================================================================
+
+package harvest
+
+import scala.xml.XML
+import org.scalatest.flatspec._
+import org.scalatest.matchers._
+
+import harvest.Harvesting.PMHHarvestPage
+
+class PMHHarvestPageRecordCountSpec extends AnyFlatSpec with should.Matchers {
+
+  private val pageWithoutResumption =
+    <OAI-PMH>
+      <ListRecords>
+        <record><header><identifier>id-1</identifier></header></record>
+        <record><header><identifier>id-2</identifier></header></record>
+        <record><header><identifier>id-3</identifier></header></record>
+        <record><header><identifier>id-4</identifier></header></record>
+        <record><header><identifier>id-5</identifier></header></record>
+      </ListRecords>
+    </OAI-PMH>
+
+  private val pageWithResumption =
+    <OAI-PMH>
+      <ListRecords>
+        <record><header><identifier>id-1</identifier></header></record>
+        <record><header><identifier>id-2</identifier></header></record>
+        <record><header><identifier>id-3</identifier></header></record>
+        <record><header><identifier>id-4</identifier></header></record>
+        <record><header><identifier>id-5</identifier></header></record>
+        <resumptionToken completeListSize="100" cursor="1">opaque</resumptionToken>
+      </ListRecords>
+    </OAI-PMH>
+
+  "PMHHarvestPage" should "accept a recordCount field that reflects the actual record count" in {
+    val page = PMHHarvestPage(
+      records = pageWithoutResumption.toString,
+      url = "https://example.org/oai",
+      set = "",
+      metadataPrefix = "edm",
+      totalRecords = 0,
+      strategy = dataset.DatasetActor.Sample,
+      resumptionToken = None,
+      deletedIds = List.empty,
+      deletedCount = 0,
+      recordCount = (pageWithoutResumption \ "ListRecords" \ "record").size
+    )
+    page.recordCount shouldBe 5
+    page.totalRecords shouldBe 0
+  }
+
+  it should "accept a PMHHarvestPage where totalRecords reflects completeListSize and recordCount is the page size" in {
+    val page = PMHHarvestPage(
+      records = pageWithResumption.toString,
+      url = "https://example.org/oai",
+      set = "",
+      metadataPrefix = "edm",
+      totalRecords = 100,
+      strategy = dataset.DatasetActor.Sample,
+      resumptionToken = None,
+      deletedIds = List.empty,
+      deletedCount = 0,
+      recordCount = (pageWithResumption \ "ListRecords" \ "record").size
+    )
+    page.recordCount shouldBe 5
+    page.totalRecords shouldBe 100
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JDK_JAVA_OPTIONS="" sbt "testOnly harvest.PMHHarvestPageRecordCountSpec"`
+Expected: FAIL with a compile error — something like `unknown parameter name: recordCount` on the `PMHHarvestPage` constructor call (or `too many arguments for PMHHarvestPage`).
+
+- [ ] **Step 3: Add the field to `PMHHarvestPage`**
+
+In `app/harvest/Harvesting.scala`, lines 98-109 currently read:
+
+```scala
+  case class PMHHarvestPage
+  (
+    records: String,
+    url: String,
+    set: String,
+    metadataPrefix: String,
+    totalRecords: Int,
+    strategy: HarvestStrategy,
+    resumptionToken: Option[PMHResumptionToken],
+    deletedIds: List[String] = List.empty,    // Record IDs with status="deleted"
+    deletedCount: Int = 0                     // Count of deleted records in this page
+  )
+```
+
+Replace with:
+
+```scala
+  case class PMHHarvestPage
+  (
+    records: String,
+    url: String,
+    set: String,
+    metadataPrefix: String,
+    totalRecords: Int,
+    strategy: HarvestStrategy,
+    resumptionToken: Option[PMHResumptionToken],
+    deletedIds: List[String] = List.empty,    // Record IDs with status="deleted"
+    deletedCount: Int = 0,                    // Count of deleted records in this page
+    recordCount: Int = 0                      // Actual number of <record> elements on this page
+  )
+```
+
+- [ ] **Step 4: Populate `recordCount` in `fetchPMHPage`**
+
+In `app/harvest/Harvesting.scala`, lines 460-470 currently construct the `PMHHarvestPage`:
+
+```scala
+            val harvestPage = PMHHarvestPage(
+              records = xml.toString(),
+              url = resolvedUrl,
+              set = set,
+              metadataPrefix = metadataPrefix,
+              totalRecords = total,
+              strategy,
+              resumptionToken = newToken,
+              deletedIds = deletedIds,
+              deletedCount = deletedIds.size
+```
+
+Replace the closing parenthesis on the `deletedCount` line with a comma and add `recordCount = allRecords.size`:
+
+```scala
+            val harvestPage = PMHHarvestPage(
+              records = xml.toString(),
+              url = resolvedUrl,
+              set = set,
+              metadataPrefix = metadataPrefix,
+              totalRecords = total,
+              strategy,
+              resumptionToken = newToken,
+              deletedIds = deletedIds,
+              deletedCount = deletedIds.size,
+              recordCount = allRecords.size
+```
+
+`allRecords` is already defined at line 437: `val allRecords = xml \ "ListRecords" \ "record"`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `JDK_JAVA_OPTIONS="" sbt "testOnly harvest.PMHHarvestPageRecordCountSpec"`
+Expected: PASS — both tests green.
+
+- [ ] **Step 6: Compile full build to catch any other call sites**
+
+Run: `JDK_JAVA_OPTIONS="" make compile`
+Expected: BUILD SUCCESS. If any other file constructs `PMHHarvestPage` positionally (not by name), a compile error will surface; the new field has a default so this should not happen.
+
+- [ ] **Step 7: Human diff review**
+
+Reference skill: diff-review-before-task-commit
+Wait for human acknowledgment before proceeding to commit.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/harvest/Harvesting.scala test/harvest/PMHHarvestPageRecordCountSpec.scala
+git commit -m "feat: add PMHHarvestPage.recordCount derived from parsed XML"
+```
+
+---
+
+## Task 2: Use the fallback in the PMH sample handler
+
+**Files:**
+- Modify: `app/harvest/Harvester.scala` (lines 743-748)
+
+The PMH sample handler currently passes `page.totalRecords` to `setAcquisitionCounts`. Replace with a fallback that prefers `totalRecords` (the catalog total from `completeListSize`) but uses the actual `recordCount` when `totalRecords` is zero.
+
+- [ ] **Step 1: Read current code**
+
+In `app/harvest/Harvester.scala`, lines 743-748 currently read:
+
+```scala
+              FileUtils.writeStringToFile(rawXml, page.records, "UTF-8")
+              datasetContext.dsInfo.setAcquisitionCounts(
+                acquired = page.totalRecords,
+                deleted = 0,
+                source = page.totalRecords,
+                method = "pmh"
+              )
+```
+
+- [ ] **Step 2: Replace with fallback expression**
+
+Replace those lines with:
+
+```scala
+              FileUtils.writeStringToFile(rawXml, page.records, "UTF-8")
+              val sampled = if (page.totalRecords > 0) page.totalRecords else page.recordCount
+              datasetContext.dsInfo.setAcquisitionCounts(
+                acquired = sampled,
+                deleted = 0,
+                source = sampled,
+                method = "pmh"
+              )
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `JDK_JAVA_OPTIONS="" make compile`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Run full harvest + dataset tests to catch regressions**
+
+Run: `JDK_JAVA_OPTIONS="" sbt "testOnly harvest.* dataset.*"`
+Expected: all tests PASS, including the new `PMHHarvestPageRecordCountSpec` and the existing `HarvestingFromFormatSpec` / `DsInfoSerializationSpec`.
+
+- [ ] **Step 5: Human diff review**
+
+Reference skill: diff-review-before-task-commit
+Wait for human acknowledgment before proceeding to commit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/harvest/Harvester.scala
+git commit -m "$(cat <<'EOF'
+fix: use actual record count when OAI-PMH server omits completeListSize
+
+PMH sample writes setAcquisitionCounts(acquired = page.totalRecords).
+When the server returns no resumption token (sample response fits in
+one page, as with Brocade/Anet), totalRecords defaults to 0 and the
+frontend dialog misidentifies the successful sample as an empty result.
+
+Fall back to the actual XML record count when totalRecords is zero.
+Preserves catalog-total semantics when completeListSize is present.
+EOF
+)"
+```
+
+---
+
+## Task 3: Manual smoke test (human only)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the app locally**
+
+Run: `JDK_JAVA_OPTIONS="" make run`
+Wait for "Play - Application started (Dev)" log line.
+
+- [ ] **Step 2: Trigger a sample harvest on the Brocade dataset**
+
+Navigate to `http://localhost:9000/narthex/#/?dataset=brocade-cat-rsl` in a browser. Click the sample-harvest action (the page offers it alongside other harvest actions).
+
+- [ ] **Step 3: Verify no false-alarm dialog**
+
+After the sample completes, the "Sample Harvest: 0 Records" confirm dialog should NOT appear. The dataset detail panel should show a non-zero `acquiredRecordCount` that matches the number of records actually returned by the Brocade endpoint.
+
+- [ ] **Step 4: Regression — sample against an endpoint with zero results**
+
+Pick (or temporarily configure) a dataset whose OAI-PMH endpoint returns no records for the sample verb. Trigger the sample. The dialog should fire — this is the legitimate signal, preserved by this change.
+
+If the regression case fails (dialog does not fire for genuinely empty results), stop. The XML record count fallback is firing when it should not.
+
+---
+
+## Self-Review Checklist (post-write)
+
+- ✅ **Spec coverage:** All three file changes from the spec map to Tasks 1-2. Spec testing section (unit + manual smoke) maps to Task 1 (TDD) + Task 3 (manual smoke). Scope intentionally excludes Fix 2 per revised spec.
+- ✅ **No placeholders:** Every step has exact code or exact command.
+- ✅ **Type consistency:** `PMHHarvestPage.recordCount: Int` defined in Task 1, referenced as `page.recordCount` in Task 2. `allRecords.size` is the same value populating `recordCount` that drives the test assertions. `setAcquisitionCounts` signature matches the existing DsInfo method.

--- a/docs/specs/2026-04-21-sample-harvest-zero-records-false-alarm-design.md
+++ b/docs/specs/2026-04-21-sample-harvest-zero-records-false-alarm-design.md
@@ -1,0 +1,161 @@
+# Sample Harvest "0 Records" False-Alarm Dialog
+
+**Status:** Designed, not yet implemented
+**Date:** 2026-04-21
+**Branch:** `fix/sample-harvest-zero-records-false-alarm`
+
+## Problem
+
+The dataset list UI shows a "Sample Harvest: 0 Records" confirmation dialog
+that asks the operator whether to reset record counts to zero. The dialog
+fires when, in fact, the harvest succeeded with data. Two distinct triggers,
+same root cause (frontend infers "harvest empty" from incomplete state):
+
+### Trigger 1 — Sample harvest on any dataset
+
+`Harvester.scala:743-748` (PMH sample handler) writes
+`setAcquisitionCounts(acquired = page.totalRecords, ...)`. The
+`totalRecords` value comes from the OAI-PMH `<resumptionToken
+completeListSize="...">` attribute. When the sample response fits in one page
+and the server omits the resumption token (Brocade/Anet on small samples),
+`Harvesting.scala:420-423` defaults `total = 0`. Sample writes
+`acquiredRecordCount = 0` even though the response contained records.
+
+The frontend dialog at `dataset-list-controllers.js:204-208` checks
+`acquiredRecordCount === 0` (among others) and fires a confirm dialog.
+
+### Trigger 2 — First-ever full harvest on a fresh dataset
+
+State changes propagate through WebSocket as separate frames:
+
+1. Harvest starts → `currentOperation = "HARVESTING"`, `stateRaw` set → frame 1
+2. Records ingest → `acquiredRecordCount` written → frame 2
+3. Harvest completes → `currentOperation` cleared, `stateSourced` set → frame 3
+
+For a never-sourced dataset, frame 1 hits the frontend with
+`previousStateRaw = null`, `acquiredRecordCount = 0`, `stateSourced = null`
+— all three current dialog conditions are transiently true → dialog fires
+mid-harvest, then later frames clear the conditions but the dialog already
+opened.
+
+## Goal
+
+Stop the false-alarm dialog without removing the legitimate signal (sample
+that genuinely returned zero records). Two complementary fixes addressing
+the two triggers.
+
+## Non-goals
+
+- AdLib sample (already correct via `diagnostic.totalItems`)
+- JSON harvest (no sample path)
+- Restructuring the WebSocket message protocol
+- Changing the dialog text or its "reset counts to 0" callback
+
+## Approach
+
+### Fix 1 — Backend: derive accurate sample count
+
+Add `recordCount: Int` field to `PMHHarvestPage`, populated from the parsed
+XML record list during `fetchPMHPage`. Symmetric with the existing
+`deletedCount` field, single source of truth for "how many records did this
+page actually contain."
+
+The PMH sample handler picks the count via fallback:
+
+```scala
+val sampled = if (page.totalRecords > 0) page.totalRecords else page.recordCount
+```
+
+`completeListSize` (when present) is preferred because it reflects the
+catalog total, useful for progress display elsewhere. The XML record count
+is the truthful fallback when `completeListSize` is absent or zero.
+
+### Fix 2 — Frontend: gate dialog on operation completion
+
+Add a fourth condition to the dialog check at
+`dataset-list-controllers.js:204-208`:
+
+```js
+var noOperationInProgress = !existingDataset.currentOperation;
+```
+
+Dialog only fires when an operation has fully completed (no
+`currentOperation` set). Eliminates the first-full-harvest race because
+mid-harvest WebSocket frames carry `currentOperation = "HARVESTING"` and
+fail the new gate.
+
+The fix preserves the legitimate trigger: when sample genuinely returns zero
+records, the `noRecordsMatch` path in `Harvester.scala:750-752` does not
+write counts; `DatasetActor.scala:889-893` sets state RAW (Sample bypasses
+the workflow state machine, so `currentOperation` is not set during sample);
+all four conditions are true → dialog fires correctly.
+
+## File changes
+
+| File | Change |
+|---|---|
+| `app/harvest/Harvesting.scala` (`PMHHarvestPage` ~line 98-109) | Add `recordCount: Int = 0` field |
+| `app/harvest/Harvesting.scala` (`fetchPMHPage` ~line 449) | Set `recordCount = allRecords.size` from already-parsed `xml \ "ListRecords" \ "record"` |
+| `app/harvest/Harvester.scala:743-748` | Compute `val sampled = if (page.totalRecords > 0) page.totalRecords else page.recordCount`; pass `sampled` as both `acquired` and `source` to `setAcquisitionCounts` |
+| `app/assets/javascripts/datasetList/dataset-list-controllers.js:204-208` | Add `var noOperationInProgress = !existingDataset.currentOperation;` and append `&& noOperationInProgress` to the `if` condition |
+
+## Data flow
+
+### Sample with data (Brocade scenario, currently broken)
+
+1. User triggers sample → `Harvester` issues `fetchPMHPage`
+2. `fetchPMHPage` parses 5 records, no resumption token →
+   `PMHHarvestPage(records, ..., totalRecords = 0, ..., recordCount = 5)`
+3. PMH sample handler computes `sampled = 5`, writes
+   `setAcquisitionCounts(5, 0, 5, "pmh")`
+4. `DatasetActor` Sample case sets state RAW (unchanged)
+5. WebSocket frame: `stateRaw = set, acquiredRecordCount = 5,
+   currentOperation = null`
+6. Frontend: `noRecordsAcquired = false` → dialog skipped ✅
+
+### First full harvest on a fresh dataset (currently broken)
+
+1. Harvest starts → `currentOperation = "HARVESTING"`, `stateRaw` set →
+   WebSocket frame 1
+2. Frontend: `noOperationInProgress = false` → dialog skipped ✅
+3. Records ingest → counts set → frame 2; still mid-harvest
+4. Harvest completes → `currentOperation` cleared, `stateSourced` set →
+   frame 3
+5. Frontend: `notSourced = false` → dialog skipped ✅
+
+### Sample with truly 0 records (legitimate signal, must still fire)
+
+1. `noRecordsMatch` path runs (`Harvester.scala:750-752`); no count call
+2. `DatasetActor` Sample case sets state RAW
+3. WebSocket frame: `stateRaw = set, acquiredRecordCount = 0,
+   stateSourced = null, currentOperation = null`
+4. All four conditions true → dialog fires correctly ✅
+
+## Error handling
+
+- XML parse failures still propagate through the existing `Try` wrappers in
+  `fetchPMHPage`; no new error paths.
+- `recordCount` defaults to 0 — same as today's behavior for any caller that
+  does not explicitly read it. Backward-compatible field addition.
+- If `currentOperation` is `undefined` on a stale dataset object,
+  `!undefined === true` → dialog can fire if the other conditions match.
+  Matches today's behavior (no regression).
+
+## Testing
+
+### Unit (Scala)
+
+- `HarvestingSpec` (new or extended): fixture OAI-PMH XML with 5 records and
+  no resumption token → assert `PMHHarvestPage.recordCount == 5,
+  totalRecords == 0`.
+- Same fixture with `<resumptionToken completeListSize="100">` → assert
+  `totalRecords == 100, recordCount == 5`.
+
+### Manual smoke
+
+- Sample harvest on `brocade-cat-rsl` → no dialog, dataset detail panel
+  shows non-zero record count after sample completes.
+- First-ever full harvest on a fresh test dataset → no transient dialog
+  during harvest progression.
+- Regression: sample on a fresh test dataset against an OAI-PMH endpoint
+  that returns zero records → dialog still fires (correct behavior).

--- a/docs/specs/2026-04-21-sample-harvest-zero-records-false-alarm-design.md
+++ b/docs/specs/2026-04-21-sample-harvest-zero-records-false-alarm-design.md
@@ -7,58 +7,44 @@
 ## Problem
 
 The dataset list UI shows a "Sample Harvest: 0 Records" confirmation dialog
-that asks the operator whether to reset record counts to zero. The dialog
-fires when, in fact, the harvest succeeded with data. Two distinct triggers,
-same root cause (frontend infers "harvest empty" from incomplete state):
-
-### Trigger 1 — Sample harvest on any dataset
+asking the operator whether to reset record counts to zero. The dialog fires
+even when the sample harvest succeeded with data.
 
 `Harvester.scala:743-748` (PMH sample handler) writes
 `setAcquisitionCounts(acquired = page.totalRecords, ...)`. The
 `totalRecords` value comes from the OAI-PMH `<resumptionToken
-completeListSize="...">` attribute. When the sample response fits in one page
-and the server omits the resumption token (Brocade/Anet on small samples),
-`Harvesting.scala:420-423` defaults `total = 0`. Sample writes
-`acquiredRecordCount = 0` even though the response contained records.
+completeListSize="...">` attribute. When the sample response fits in one
+page and the server omits the resumption token (Brocade/Anet on small
+samples), `Harvesting.scala:431-434` defaults `total = 0`. Sample writes
+`acquiredRecordCount = 0` even when records were returned.
 
 The frontend dialog at `dataset-list-controllers.js:204-208` checks
-`acquiredRecordCount === 0` (among others) and fires a confirm dialog.
-
-### Trigger 2 — First-ever full harvest on a fresh dataset
-
-State changes propagate through WebSocket as separate frames:
-
-1. Harvest starts → `currentOperation = "HARVESTING"`, `stateRaw` set → frame 1
-2. Records ingest → `acquiredRecordCount` written → frame 2
-3. Harvest completes → `currentOperation` cleared, `stateSourced` set → frame 3
-
-For a never-sourced dataset, frame 1 hits the frontend with
-`previousStateRaw = null`, `acquiredRecordCount = 0`, `stateSourced = null`
-— all three current dialog conditions are transiently true → dialog fires
-mid-harvest, then later frames clear the conditions but the dialog already
-opened.
+`acquiredRecordCount === 0` (among other conditions) and fires a confirm
+dialog. Since sample succeeded but the count is wrong, the dialog
+mischaracterises a successful sample as an empty result.
 
 ## Goal
 
-Stop the false-alarm dialog without removing the legitimate signal (sample
-that genuinely returned zero records). Two complementary fixes addressing
-the two triggers.
+Stop the false-alarm dialog without removing the legitimate signal — sample
+that genuinely returned zero records.
 
 ## Non-goals
 
 - AdLib sample (already correct via `diagnostic.totalItems`)
 - JSON harvest (no sample path)
-- Restructuring the WebSocket message protocol
-- Changing the dialog text or its "reset counts to 0" callback
+- Frontend dialog logic itself (correct behaviour given correct data)
+- The "reset counts" command path or any other `setState(RAW)` site
+- A separate, unverified report of the dialog firing on "manual reharvest"
+  — `setState(RAW)` is not called by the FromScratch full-harvest path, so
+  that report cannot be triggered by FromScratch directly. If it reproduces
+  after this fix, investigate separately.
 
 ## Approach
 
-### Fix 1 — Backend: derive accurate sample count
-
 Add `recordCount: Int` field to `PMHHarvestPage`, populated from the parsed
 XML record list during `fetchPMHPage`. Symmetric with the existing
-`deletedCount` field, single source of truth for "how many records did this
-page actually contain."
+`deletedCount` field, and the right single source of truth for "how many
+records did this page actually contain."
 
 The PMH sample handler picks the count via fallback:
 
@@ -70,34 +56,13 @@ val sampled = if (page.totalRecords > 0) page.totalRecords else page.recordCount
 catalog total, useful for progress display elsewhere. The XML record count
 is the truthful fallback when `completeListSize` is absent or zero.
 
-### Fix 2 — Frontend: gate dialog on operation completion
-
-Add a fourth condition to the dialog check at
-`dataset-list-controllers.js:204-208`:
-
-```js
-var noOperationInProgress = !existingDataset.currentOperation;
-```
-
-Dialog only fires when an operation has fully completed (no
-`currentOperation` set). Eliminates the first-full-harvest race because
-mid-harvest WebSocket frames carry `currentOperation = "HARVESTING"` and
-fail the new gate.
-
-The fix preserves the legitimate trigger: when sample genuinely returns zero
-records, the `noRecordsMatch` path in `Harvester.scala:750-752` does not
-write counts; `DatasetActor.scala:889-893` sets state RAW (Sample bypasses
-the workflow state machine, so `currentOperation` is not set during sample);
-all four conditions are true → dialog fires correctly.
-
 ## File changes
 
 | File | Change |
 |---|---|
-| `app/harvest/Harvesting.scala` (`PMHHarvestPage` ~line 98-109) | Add `recordCount: Int = 0` field |
-| `app/harvest/Harvesting.scala` (`fetchPMHPage` ~line 449) | Set `recordCount = allRecords.size` from already-parsed `xml \ "ListRecords" \ "record"` |
+| `app/harvest/Harvesting.scala` (`PMHHarvestPage` lines 98-109) | Add `recordCount: Int = 0` field |
+| `app/harvest/Harvesting.scala` (`fetchPMHPage` constructor call lines 460-470) | Set `recordCount = allRecords.size` from the already-parsed value at line 437 |
 | `app/harvest/Harvester.scala:743-748` | Compute `val sampled = if (page.totalRecords > 0) page.totalRecords else page.recordCount`; pass `sampled` as both `acquired` and `source` to `setAcquisitionCounts` |
-| `app/assets/javascripts/datasetList/dataset-list-controllers.js:204-208` | Add `var noOperationInProgress = !existingDataset.currentOperation;` and append `&& noOperationInProgress` to the `if` condition |
 
 ## Data flow
 
@@ -109,19 +74,9 @@ all four conditions are true → dialog fires correctly.
 3. PMH sample handler computes `sampled = 5`, writes
    `setAcquisitionCounts(5, 0, 5, "pmh")`
 4. `DatasetActor` Sample case sets state RAW (unchanged)
-5. WebSocket frame: `stateRaw = set, acquiredRecordCount = 5,
-   currentOperation = null`
+5. `WebSocketIdleBroadcast` fires after `clearOperation`. Frame carries
+   `stateRaw = set, acquiredRecordCount = 5, currentOperation = null`
 6. Frontend: `noRecordsAcquired = false` → dialog skipped ✅
-
-### First full harvest on a fresh dataset (currently broken)
-
-1. Harvest starts → `currentOperation = "HARVESTING"`, `stateRaw` set →
-   WebSocket frame 1
-2. Frontend: `noOperationInProgress = false` → dialog skipped ✅
-3. Records ingest → counts set → frame 2; still mid-harvest
-4. Harvest completes → `currentOperation` cleared, `stateSourced` set →
-   frame 3
-5. Frontend: `notSourced = false` → dialog skipped ✅
 
 ### Sample with truly 0 records (legitimate signal, must still fire)
 
@@ -129,7 +84,7 @@ all four conditions are true → dialog fires correctly.
 2. `DatasetActor` Sample case sets state RAW
 3. WebSocket frame: `stateRaw = set, acquiredRecordCount = 0,
    stateSourced = null, currentOperation = null`
-4. All four conditions true → dialog fires correctly ✅
+4. All three conditions true → dialog fires correctly ✅
 
 ## Error handling
 
@@ -137,9 +92,6 @@ all four conditions are true → dialog fires correctly.
   `fetchPMHPage`; no new error paths.
 - `recordCount` defaults to 0 — same as today's behavior for any caller that
   does not explicitly read it. Backward-compatible field addition.
-- If `currentOperation` is `undefined` on a stale dataset object,
-  `!undefined === true` → dialog can fire if the other conditions match.
-  Matches today's behavior (no regression).
 
 ## Testing
 
@@ -155,7 +107,11 @@ all four conditions are true → dialog fires correctly.
 
 - Sample harvest on `brocade-cat-rsl` → no dialog, dataset detail panel
   shows non-zero record count after sample completes.
-- First-ever full harvest on a fresh test dataset → no transient dialog
-  during harvest progression.
 - Regression: sample on a fresh test dataset against an OAI-PMH endpoint
   that returns zero records → dialog still fires (correct behavior).
+- Operator reports of the dialog firing on "manual reharvest" should be
+  re-verified after this fix lands. If it still reproduces, capture the
+  WebSocket frame at the moment of firing (the broadcast carries
+  `stateRaw`, `stateSourced`, `acquiredRecordCount`, `currentOperation`)
+  and identify which state path triggered RAW (Sample? upload? "reset
+  counts"? retry?). Address as a separate spec.

--- a/test/harvest/PMHHarvestPageRecordCountSpec.scala
+++ b/test/harvest/PMHHarvestPageRecordCountSpec.scala
@@ -1,0 +1,83 @@
+//===========================================================================
+//    Copyright 2026 Delving B.V.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//===========================================================================
+
+package harvest
+
+import scala.xml.XML
+import org.scalatest.flatspec._
+import org.scalatest.matchers._
+
+import harvest.Harvesting.PMHHarvestPage
+
+class PMHHarvestPageRecordCountSpec extends AnyFlatSpec with should.Matchers {
+
+  private val pageWithoutResumption =
+    <OAI-PMH>
+      <ListRecords>
+        <record><header><identifier>id-1</identifier></header></record>
+        <record><header><identifier>id-2</identifier></header></record>
+        <record><header><identifier>id-3</identifier></header></record>
+        <record><header><identifier>id-4</identifier></header></record>
+        <record><header><identifier>id-5</identifier></header></record>
+      </ListRecords>
+    </OAI-PMH>
+
+  private val pageWithResumption =
+    <OAI-PMH>
+      <ListRecords>
+        <record><header><identifier>id-1</identifier></header></record>
+        <record><header><identifier>id-2</identifier></header></record>
+        <record><header><identifier>id-3</identifier></header></record>
+        <record><header><identifier>id-4</identifier></header></record>
+        <record><header><identifier>id-5</identifier></header></record>
+        <resumptionToken completeListSize="100" cursor="1">opaque</resumptionToken>
+      </ListRecords>
+    </OAI-PMH>
+
+  "PMHHarvestPage" should "accept a recordCount field that reflects the actual record count" in {
+    val page = PMHHarvestPage(
+      records = pageWithoutResumption.toString,
+      url = "https://example.org/oai",
+      set = "",
+      metadataPrefix = "edm",
+      totalRecords = 0,
+      strategy = dataset.DatasetActor.Sample,
+      resumptionToken = None,
+      deletedIds = List.empty,
+      deletedCount = 0,
+      recordCount = (pageWithoutResumption \ "ListRecords" \ "record").size
+    )
+    page.recordCount shouldBe 5
+    page.totalRecords shouldBe 0
+  }
+
+  it should "accept a PMHHarvestPage where totalRecords reflects completeListSize and recordCount is the page size" in {
+    val page = PMHHarvestPage(
+      records = pageWithResumption.toString,
+      url = "https://example.org/oai",
+      set = "",
+      metadataPrefix = "edm",
+      totalRecords = 100,
+      strategy = dataset.DatasetActor.Sample,
+      resumptionToken = None,
+      deletedIds = List.empty,
+      deletedCount = 0,
+      recordCount = (pageWithResumption \ "ListRecords" \ "record").size
+    )
+    page.recordCount shouldBe 5
+    page.totalRecords shouldBe 100
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes the "Sample Harvest: 0 Records" confirm dialog firing after a successful PMH sample against servers that omit the OAI-PMH `<resumptionToken completeListSize="...">` attribute (Brocade/Anet).
- Sample handler in \`Harvester.scala:743\` writes \`setAcquisitionCounts(acquired = page.totalRecords, ...)\`. When \`completeListSize\` is missing, \`Harvesting.scala\` defaults \`total = 0\`, so the sample wrote \`acquiredRecordCount = 0\` even on success → frontend dialog mischaracterised the result.
- New \`PMHHarvestPage.recordCount\` field is populated from the parsed XML record list. Sample handler now uses fallback: \`if (page.totalRecords > 0) page.totalRecords else page.recordCount\`. Catalog-total semantics preserved when \`completeListSize\` is present.

## Out of scope

- AdLib sample (already correct via \`diagnostic.totalItems\`).
- JSON sample may have an analogous bug (no \`recordCount\` equivalent on \`JsonHarvestPage\`); deferred.
- Frontend dialog logic itself (correct given correct data).
- Operator reports of the dialog firing on "manual reharvest" — \`setState(RAW)\` is not called by the FromScratch full-harvest path, so that report cannot be triggered by FromScratch directly. If it reproduces after this fix, investigate separately.

## Spec & plan

- \`docs/specs/2026-04-21-sample-harvest-zero-records-false-alarm-design.md\`
- \`docs/plans/2026-04-21-sample-harvest-zero-records-false-alarm-plan.md\`

## Test Plan

- [x] Unit: \`PMHHarvestPageRecordCountSpec\` — fixture XML with 5 records, with and without resumption token; asserts \`recordCount=5\` and \`totalRecords\` semantics
- [x] Full \`make compile\` clean; \`sbt "testOnly harvest.* dataset.*"\` 14/14 green
- [x] Manual smoke against Brocade endpoint — operator confirmed dialog no longer fires and dataset shows non-zero count after sample
- [ ] Reviewer: confirm regression case (sample against an endpoint that genuinely returns zero records → dialog still fires correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)