### PR TITLE
fix(trends): address 15 correctness + perf issues in trends feature

### DIFF
--- a/app/assets/javascripts/datasetList/main.js
+++ b/app/assets/javascripts/datasetList/main.js
@@ -15,13 +15,13 @@ define(
                 function ($routeProvider) {
                     $routeProvider.when(
                         "/", {
-                            templateUrl: "/narthex/assets/templates/dataset-list.html?v=0.8.7.18",
+                            templateUrl: "/narthex/assets/templates/dataset-list.html?v=0.8.7.19",
                             controller: controllers.DatasetListCtrl,
                             reloadOnSearch: false
                         }
                     ).when(
                         "/sip-creator", {
-                            templateUrl: "/narthex/assets/templates/sip-creator-downloads.html?v=0.8.7.18",
+                            templateUrl: "/narthex/assets/templates/sip-creator-downloads.html?v=0.8.7.19",
                             controller: 'SipCreatorDownloadsCtrl'
                         }
                     );

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -23,7 +23,7 @@
     // Increase timeout for slower connections/browsers (default is 7 seconds)
     waitSeconds: 30,
     // Cache busting: static version for r.js build (update when making releases)
-    urlArgs: "v=0.8.7.18",
+    urlArgs: "v=0.8.7.19",
     // Packages = top-level folders; loads a contained file named "main.js"
     packages: [
       "common", "datasetList", "dataset", "datasetDelimiter", "skos", "terms", "categories", "defaultMappings", "stats", "discovery", "indexStats", "trends"

--- a/app/controllers/AppController.scala
+++ b/app/controllers/AppController.scala
@@ -284,22 +284,26 @@ class AppController @Inject() (
             indexed = summaries.map(_.delta24h.indexed).sum
           )
 
-          // Categorize datasets
+          // Categorize datasets — include valid delta so datasets whose processed
+          // counts moved (even with unchanged source/indexed) don't hide in stable.
           val growing = summaries.filter(s =>
-            s.delta24h.source > 0 || s.delta24h.indexed > 0
-          ).sortBy(s => -(s.delta24h.source + s.delta24h.indexed))
+            s.delta24h.source > 0 || s.delta24h.indexed > 0 || s.delta24h.valid > 0
+          ).sortBy(s => -(s.delta24h.source + s.delta24h.indexed + s.delta24h.valid))
 
           val shrinking = summaries.filter(s =>
-            s.delta24h.source < 0 || s.delta24h.indexed < 0
-          ).sortBy(s => s.delta24h.source + s.delta24h.indexed)
+            s.delta24h.source < 0 || s.delta24h.indexed < 0 || s.delta24h.valid < 0
+          ).sortBy(s => s.delta24h.source + s.delta24h.indexed + s.delta24h.valid)
 
           val stable = summaries.filter(s =>
-            s.delta24h.source == 0 && s.delta24h.indexed == 0
+            s.delta24h.source == 0 && s.delta24h.indexed == 0 && s.delta24h.valid == 0
           ).sortBy(_.spec)
 
           val orgTrends = OrganizationTrends(
             generatedAt = DateTime.now(org.joda.time.DateTimeZone.UTC),
-            totalDatasets = datasets.size,
+            // Use summaries.size so this matches the cached-path (buildOrganizationTrends)
+            // which also reports count of datasets with trend data, not count of
+            // all known datasets. Otherwise the number flickers on refresh.
+            totalDatasets = summaries.size,
             totalSourceRecords = summaries.map(_.currentSource.toLong).sum,
             totalIndexedRecords = summaries.map(_.currentIndexed.toLong).sum,
             netDelta24h = netDelta24h,

--- a/app/controllers/AppController.scala
+++ b/app/controllers/AppController.scala
@@ -335,57 +335,67 @@ class AppController @Inject() (
     val today = org.joda.time.LocalDate.now().toString("yyyy-MM-dd")
 
     listDsInfo(orgContext).flatMap { datasets =>
-      indexStatsService.fetchHub3IndexCounts().map { case (_, hub3Counts) =>
-        var captured = 0
-        val specs = scala.collection.mutable.ListBuffer[String]()
+      indexStatsService.fetchHub3IndexCounts().map { hub3 =>
+        if (!hub3.reachable) {
+          logger.warn("Manual trend snapshot skipped: Hub3 unreachable")
+          ServiceUnavailable(Json.obj(
+            "error" -> "Hub3 unreachable",
+            "datasetsProcessed" -> 0,
+            "snapshotsCaptured" -> 0
+          ))
+        } else {
+          val hub3Counts = hub3.counts
+          var captured = 0
+          val specs = scala.collection.mutable.ListBuffer[String]()
 
-        datasets.foreach { dsInfo =>
+          datasets.foreach { dsInfo =>
+            try {
+              val ctx = orgContext.datasetContext(dsInfo.spec)
+              val sourceRecords = dsInfo.getLiteralProp(sourceRecordCount).map(_.toInt).getOrElse(0)
+              val acquiredRecords = dsInfo.getLiteralProp(acquiredRecordCount).map(_.toInt).getOrElse(0)
+              val deletedRecords = dsInfo.getLiteralProp(deletedRecordCount).map(_.toInt).getOrElse(0)
+              val validRecords = dsInfo.getLiteralProp(processedValid).map(_.toInt).getOrElse(0)
+              val invalidRecords = dsInfo.getLiteralProp(processedInvalid).map(_.toInt).getOrElse(0)
+              val indexedRecords = hub3Counts.getOrElse(dsInfo.spec, 0)
+
+              TrendTrackingService.captureEventSnapshot(
+                trendsLog = ctx.trendsLog,
+                event = "manual",
+                sourceRecords = sourceRecords,
+                acquiredRecords = acquiredRecords,
+                deletedRecords = deletedRecords,
+                validRecords = validRecords,
+                invalidRecords = invalidRecords,
+                indexedRecords = indexedRecords
+              )
+
+              TrendTrackingService.aggregateDay(ctx.trendsLog, ctx.trendsDailyLog, today)
+
+              specs += dsInfo.spec
+              captured += 1
+            } catch {
+              case e: Exception =>
+                logger.warn(s"Failed to capture snapshot for ${dsInfo.spec}: ${e.getMessage}")
+            }
+          }
+
           try {
-            val ctx = orgContext.datasetContext(dsInfo.spec)
-            val sourceRecords = dsInfo.getLiteralProp(sourceRecordCount).map(_.toInt).getOrElse(0)
-            val acquiredRecords = dsInfo.getLiteralProp(acquiredRecordCount).map(_.toInt).getOrElse(0)
-            val deletedRecords = dsInfo.getLiteralProp(deletedRecordCount).map(_.toInt).getOrElse(0)
-            val validRecords = dsInfo.getLiteralProp(processedValid).map(_.toInt).getOrElse(0)
-            val invalidRecords = dsInfo.getLiteralProp(processedInvalid).map(_.toInt).getOrElse(0)
-            val indexedRecords = hub3Counts.getOrElse(dsInfo.spec, 0)
-
-            TrendTrackingService.captureEventSnapshot(
-              trendsLog = ctx.trendsLog,
-              event = "manual",
-              sourceRecords = sourceRecords,
-              acquiredRecords = acquiredRecords,
-              deletedRecords = deletedRecords,
-              validRecords = validRecords,
-              invalidRecords = invalidRecords,
-              indexedRecords = indexedRecords
+            TrendTrackingService.generateTrendsSummaryFromDaily(
+              orgContext.trendsSummaryFile,
+              orgContext.datasetsDir,
+              specs.toList
             )
-
-            TrendTrackingService.aggregateDay(ctx.trendsLog, ctx.trendsDailyLog, today)
-
-            specs += dsInfo.spec
-            captured += 1
           } catch {
             case e: Exception =>
-              logger.warn(s"Failed to capture snapshot for ${dsInfo.spec}: ${e.getMessage}")
+              logger.warn(s"Failed to generate trends summary: ${e.getMessage}")
           }
-        }
 
-        try {
-          TrendTrackingService.generateTrendsSummaryFromDaily(
-            orgContext.trendsSummaryFile,
-            orgContext.datasetsDir,
-            specs.toList
-          )
-        } catch {
-          case e: Exception =>
-            logger.warn(s"Failed to generate trends summary: ${e.getMessage}")
+          Ok(Json.obj(
+            "success" -> true,
+            "datasetsProcessed" -> datasets.size,
+            "snapshotsCaptured" -> captured
+          ))
         }
-
-        Ok(Json.obj(
-          "success" -> true,
-          "datasetsProcessed" -> datasets.size,
-          "snapshotsCaptured" -> captured
-        ))
       }
     }.recover {
       case e: Exception =>

--- a/app/controllers/AppController.scala
+++ b/app/controllers/AppController.scala
@@ -298,7 +298,7 @@ class AppController @Inject() (
           ).sortBy(_.spec)
 
           val orgTrends = OrganizationTrends(
-            generatedAt = DateTime.now(),
+            generatedAt = DateTime.now(org.joda.time.DateTimeZone.UTC),
             totalDatasets = datasets.size,
             totalSourceRecords = summaries.map(_.currentSource.toLong).sum,
             totalIndexedRecords = summaries.map(_.currentIndexed.toLong).sum,
@@ -332,7 +332,7 @@ class AppController @Inject() (
   def triggerTrendSnapshot = Action.async { request =>
     import triplestore.GraphProperties._
 
-    val today = org.joda.time.LocalDate.now().toString("yyyy-MM-dd")
+    val today = org.joda.time.LocalDate.now(org.joda.time.DateTimeZone.UTC).toString("yyyy-MM-dd")
 
     listDsInfo(orgContext).flatMap { datasets =>
       indexStatsService.fetchHub3IndexCounts().map { hub3 =>

--- a/app/controllers/AppController.scala
+++ b/app/controllers/AppController.scala
@@ -262,7 +262,7 @@ class AppController @Inject() (
     import services.{TrendDelta, DatasetTrendSummary, OrganizationTrends}
 
     // Try to read from cached summary file first (fast path for 200+ datasets)
-    TrendTrackingService.readTrendsSummary(orgContext.trendsSummaryFile) match {
+    TrendTrackingService.readTrendsSummary(orgContext.trendsSummaryFile, orgContext.datasetsDir) match {
       case Some(summary) =>
         logger.debug(s"Using cached trends summary from ${summary.generatedAt}")
         val orgTrends = TrendTrackingService.buildOrganizationTrends(summary)

--- a/app/dataset/DatasetActor.scala
+++ b/app/dataset/DatasetActor.scala
@@ -1093,24 +1093,25 @@ class DatasetActor(val datasetContext: DatasetContext,
       dsInfo.setState(SAVED)
       dsInfo.setRecordsSync(false)
 
-      // Capture trend snapshot after successful save (change-gated)
+      // Capture trend snapshot after successful save (change-gated).
+      // indexedRecords is carried forward from the previous snapshot because
+      // Hub3 indexing is async; the daily aggregation job reconciles against
+      // Hub3 and writes the real indexed count.
       try {
         val sourceRecords = dsInfo.getLiteralProp(sourceRecordCount).map(_.toInt).getOrElse(0)
         val acquiredRecords = dsInfo.getLiteralProp(acquiredRecordCount).map(_.toInt).getOrElse(0)
         val deletedRecords = dsInfo.getLiteralProp(deletedRecordCount).map(_.toInt).getOrElse(0)
         val validRecords = dsInfo.getLiteralProp(processedValid).map(_.toInt).getOrElse(0)
         val invalidRecords = dsInfo.getLiteralProp(processedInvalid).map(_.toInt).getOrElse(0)
-        val indexedRecords = validRecords
 
-        TrendTrackingService.captureEventSnapshot(
+        TrendTrackingService.captureEventSnapshotCarryingIndexed(
           trendsLog = datasetContext.trendsLog,
           event = "save",
           sourceRecords = sourceRecords,
           acquiredRecords = acquiredRecords,
           deletedRecords = deletedRecords,
           validRecords = validRecords,
-          invalidRecords = invalidRecords,
-          indexedRecords = indexedRecords
+          invalidRecords = invalidRecords
         )
       } catch {
         case e: Exception =>

--- a/app/organization/OrgContext.scala
+++ b/app/organization/OrgContext.scala
@@ -103,19 +103,39 @@ class OrgContext @Inject() (
     )(new Runnable {
       override def run(): Unit = runDailyTrendAggregation()
     })(actorSystem.dispatcher)
+
+    // Bootstrap: on fresh installs (or when trend tracking has been off for a
+    // while) trends_summary.json is missing or empty, so the UI falls back to
+    // per-dataset logs that only have a handful of snapshots and shows 0 deltas
+    // for every dataset. Run one aggregation asynchronously at startup so the
+    // UI has usable data immediately instead of waiting until 00:30 tomorrow.
+    if (!trendsSummaryFile.exists() || trendsSummaryFile.length() == 0) {
+      logger.info("No trends summary found — scheduling bootstrap aggregation")
+      actorSystem.scheduler.scheduleOnce(10.seconds) {
+        runBootstrapTrendAggregation()
+      }(actorSystem.dispatcher)
+    }
+  }
+
+  private def runBootstrapTrendAggregation(): Unit = {
+    val today = org.joda.time.LocalDate.now().toString("yyyy-MM-dd")
+    logger.info(s"Running bootstrap trend aggregation for $today")
+    runTrendAggregation(today)
   }
 
   private def runDailyTrendAggregation(): Unit = {
-    logger.info("Running daily trend aggregation...")
-
     val yesterday = org.joda.time.LocalDate.now().minusDays(1).toString("yyyy-MM-dd")
+    logger.info(s"Running daily trend aggregation for $yesterday...")
+    runTrendAggregation(yesterday)
+  }
 
+  private def runTrendAggregation(date: String): Unit = {
     val result = for {
       datasets <- DsInfo.listDsInfo(this)
       hub3 <- indexStatsService.fetchHub3IndexCounts()
     } yield {
       if (!hub3.reachable) {
-        logger.warn("Skipping daily trend aggregation: Hub3 unreachable. Indexed counts would be corrupted.")
+        logger.warn(s"Skipping trend aggregation for $date: Hub3 unreachable. Indexed counts would be corrupted.")
       } else {
         var aggregated = 0
         val specs = scala.collection.mutable.ListBuffer[String]()
@@ -146,7 +166,7 @@ class OrgContext @Inject() (
               }
             }
 
-            TrendTrackingService.aggregateDay(trendsLog, dailyLog, yesterday)
+            TrendTrackingService.aggregateDay(trendsLog, dailyLog, date)
             specs += dsInfo.spec
             aggregated += 1
           } catch {
@@ -162,13 +182,13 @@ class OrgContext @Inject() (
             logger.warn(s"Failed to generate trends summary: ${e.getMessage}")
         }
 
-        logger.info(s"Daily trend aggregation complete: $aggregated/${datasets.size} datasets")
+        logger.info(s"Trend aggregation for $date complete: $aggregated/${datasets.size} datasets")
       }
     }
 
     val _ = result.recover {
       case e: Exception =>
-        logger.error(s"Daily trend aggregation failed: ${e.getMessage}", e)
+        logger.error(s"Trend aggregation for $date failed: ${e.getMessage}", e)
     }
   }
 

--- a/app/organization/OrgContext.scala
+++ b/app/organization/OrgContext.scala
@@ -118,14 +118,14 @@ class OrgContext @Inject() (
   }
 
   private def runBootstrapTrendAggregation(): Unit = {
-    val today = org.joda.time.LocalDate.now().toString("yyyy-MM-dd")
-    logger.info(s"Running bootstrap trend aggregation for $today")
+    val today = org.joda.time.LocalDate.now(org.joda.time.DateTimeZone.UTC).toString("yyyy-MM-dd")
+    logger.info(s"Running bootstrap trend aggregation for $today (UTC)")
     runTrendAggregation(today)
   }
 
   private def runDailyTrendAggregation(): Unit = {
-    val yesterday = org.joda.time.LocalDate.now().minusDays(1).toString("yyyy-MM-dd")
-    logger.info(s"Running daily trend aggregation for $yesterday...")
+    val yesterday = org.joda.time.LocalDate.now(org.joda.time.DateTimeZone.UTC).minusDays(1).toString("yyyy-MM-dd")
+    logger.info(s"Running daily trend aggregation for $yesterday (UTC)...")
     runTrendAggregation(yesterday)
   }
 

--- a/app/organization/OrgContext.scala
+++ b/app/organization/OrgContext.scala
@@ -112,51 +112,58 @@ class OrgContext @Inject() (
 
     val result = for {
       datasets <- DsInfo.listDsInfo(this)
-      (_, hub3Counts) <- indexStatsService.fetchHub3IndexCounts()
+      hub3 <- indexStatsService.fetchHub3IndexCounts()
     } yield {
-      var aggregated = 0
-      val specs = scala.collection.mutable.ListBuffer[String]()
+      if (!hub3.reachable) {
+        logger.warn("Skipping daily trend aggregation: Hub3 unreachable. Indexed counts would be corrupted.")
+      } else {
+        var aggregated = 0
+        val specs = scala.collection.mutable.ListBuffer[String]()
 
-      datasets.foreach { dsInfo =>
-        try {
-          val ctx = datasetContext(dsInfo.spec)
-          val trendsLog = ctx.trendsLog
-          val dailyLog = ctx.trendsDailyLog
+        datasets.foreach { dsInfo =>
+          try {
+            val ctx = datasetContext(dsInfo.spec)
+            val trendsLog = ctx.trendsLog
+            val dailyLog = ctx.trendsDailyLog
 
-          val hub3Count = hub3Counts.getOrElse(dsInfo.spec, 0)
+            val hub3Count = hub3.counts.getOrElse(dsInfo.spec, 0)
 
-          val lastSnapshot = TrendTrackingService.getLastSnapshot(trendsLog)
-          lastSnapshot.foreach { last =>
-            if (last.indexedRecords != hub3Count && hub3Count > 0) {
-              TrendTrackingService.captureEventSnapshot(
-                trendsLog, "daily",
-                sourceRecords = last.sourceRecords,
-                acquiredRecords = last.acquiredRecords,
-                deletedRecords = last.deletedRecords,
-                validRecords = last.validRecords,
-                invalidRecords = last.invalidRecords,
-                indexedRecords = hub3Count
-              )
+            val lastSnapshot = TrendTrackingService.getLastSnapshot(trendsLog)
+            lastSnapshot.foreach { last =>
+              // Record a "daily" reconciliation snapshot whenever our stored indexed
+              // count disagrees with what Hub3 reports. A Hub3 count of 0 is meaningful
+              // when reachable=true (dataset fully de-indexed) so it is not guarded away.
+              if (last.indexedRecords != hub3Count) {
+                TrendTrackingService.captureEventSnapshot(
+                  trendsLog, "daily",
+                  sourceRecords = last.sourceRecords,
+                  acquiredRecords = last.acquiredRecords,
+                  deletedRecords = last.deletedRecords,
+                  validRecords = last.validRecords,
+                  invalidRecords = last.invalidRecords,
+                  indexedRecords = hub3Count
+                )
+              }
             }
-          }
 
-          TrendTrackingService.aggregateDay(trendsLog, dailyLog, yesterday)
-          specs += dsInfo.spec
-          aggregated += 1
+            TrendTrackingService.aggregateDay(trendsLog, dailyLog, yesterday)
+            specs += dsInfo.spec
+            aggregated += 1
+          } catch {
+            case e: Exception =>
+              logger.warn(s"Failed to aggregate trends for ${dsInfo.spec}: ${e.getMessage}")
+          }
+        }
+
+        try {
+          TrendTrackingService.generateTrendsSummaryFromDaily(trendsSummaryFile, datasetsDir, specs.toList)
         } catch {
           case e: Exception =>
-            logger.warn(s"Failed to aggregate trends for ${dsInfo.spec}: ${e.getMessage}")
+            logger.warn(s"Failed to generate trends summary: ${e.getMessage}")
         }
-      }
 
-      try {
-        TrendTrackingService.generateTrendsSummaryFromDaily(trendsSummaryFile, datasetsDir, specs.toList)
-      } catch {
-        case e: Exception =>
-          logger.warn(s"Failed to generate trends summary: ${e.getMessage}")
+        logger.info(s"Daily trend aggregation complete: $aggregated/${datasets.size} datasets")
       }
-
-      logger.info(s"Daily trend aggregation complete: $aggregated/${datasets.size} datasets")
     }
 
     val _ = result.recover {

--- a/app/record/PocketParser.scala
+++ b/app/record/PocketParser.scala
@@ -68,11 +68,10 @@ object PocketParser {
     def writeTo(writer: Writer) = {
       val sha1: String = PocketParser.sha1(text)
       writer.write(text)
-      val normalizedId = PocketParser.cleanUpId(id)
-      if (normalizedId.contains("--")) {
-        throw new Exception(s"""subject URI cannot contain '--'; $normalizedId""")
+      if (id.contains("--")) {
+        throw new Exception(s"""subject URI cannot contain '--'; $id""")
       }
-      writer.write(s"""<!--<${normalizedId}__$sha1>-->\n""")
+      writer.write(s"""<!--<${id}__$sha1>-->\n""")
     }
   }
 

--- a/app/services/IndexStatsService.scala
+++ b/app/services/IndexStatsService.scala
@@ -70,6 +70,13 @@ object IndexStatsResponse {
 }
 
 /**
+ * Result of a Hub3 index counts fetch. `reachable` distinguishes genuine
+ * zero-record responses from network/API failures so trend aggregation can
+ * skip when Hub3 is unavailable rather than corrupting indexed counts.
+ */
+case class Hub3IndexCounts(total: Long, counts: Map[String, Int], reachable: Boolean)
+
+/**
  * Service for fetching and comparing dataset statistics between Narthex and Hub3 index
  */
 @Singleton
@@ -84,11 +91,11 @@ class IndexStatsService @Inject()(
    * Fetch index counts from Hub3 API using facet aggregation
    * @return Map of spec -> count, and total indexed documents
    */
-  def fetchHub3IndexCounts(): Future[(Long, Map[String, Int])] = {
+  def fetchHub3IndexCounts(): Future[Hub3IndexCounts] = {
     // Return empty data when in mock mode
     if (narthexConfig.mockBulkApi) {
       logger.debug("Mock mode enabled - returning empty Hub3 index counts")
-      return Future.successful((0L, Map.empty[String, Int]))
+      return Future.successful(Hub3IndexCounts(0L, Map.empty, reachable = true))
     }
 
     val url = s"${narthexConfig.naveApiUrl}/api/search/v2"
@@ -107,7 +114,7 @@ class IndexStatsService @Inject()(
       .map { response =>
         if (response.status != 200) {
           logger.error(s"Hub3 API error: ${response.status} - ${response.statusText}")
-          (0L, Map.empty[String, Int])
+          Hub3IndexCounts(0L, Map.empty, reachable = false)
         } else {
           try {
             val json = response.json
@@ -131,23 +138,26 @@ class IndexStatsService @Inject()(
                 }.toMap
 
                 logger.info(s"Fetched Hub3 index counts: $total total, ${specCounts.size} specs")
-                (total, specCounts)
+                Hub3IndexCounts(total, specCounts, reachable = true)
 
               case None =>
+                // Hub3 responded with a valid body, but the expected facet is missing.
+                // Treat as reachable-but-empty rather than unreachable so downstream
+                // callers still get an authoritative "no data for any spec" signal.
                 logger.warn("meta.spec facet not found in Hub3 response")
-                (0L, Map.empty[String, Int])
+                Hub3IndexCounts(0L, Map.empty, reachable = true)
             }
           } catch {
             case e: Exception =>
               logger.error(s"Failed to parse Hub3 response: ${e.getMessage}", e)
-              (0L, Map.empty[String, Int])
+              Hub3IndexCounts(0L, Map.empty, reachable = false)
           }
         }
       }
       .recover {
         case e: Exception =>
           logger.error(s"Failed to fetch Hub3 index counts: ${e.getMessage}", e)
-          (0L, Map.empty[String, Int])
+          Hub3IndexCounts(0L, Map.empty, reachable = false)
       }
   }
 
@@ -220,19 +230,19 @@ class IndexStatsService @Inject()(
   def getIndexAlertCounts(): Future[(Int, Int)] = {
     for {
       narthexDatasets <- fetchNarthexDatasets()
-      (_, hub3Counts) <- fetchHub3IndexCounts()
+      hub3 <- fetchHub3IndexCounts()
     } yield {
       val activeDatasets = narthexDatasets.filter(ds => !ds.deleted && !ds.disabled)
 
       // Wrong count: indexed but count doesn't match
       val wrongCount = activeDatasets.count { ds =>
-        val indexCount = hub3Counts.getOrElse(ds.spec, 0)
+        val indexCount = hub3.counts.getOrElse(ds.spec, 0)
         indexCount > 0 && !ds.processedValid.contains(indexCount)
       }
 
       // Not indexed: has valid records but not in index
       val notIndexedCount = activeDatasets.count { ds =>
-        val indexCount = hub3Counts.getOrElse(ds.spec, 0)
+        val indexCount = hub3.counts.getOrElse(ds.spec, 0)
         indexCount == 0 && ds.processedValid.exists(_ > 0)
       }
 
@@ -247,8 +257,11 @@ class IndexStatsService @Inject()(
   def getIndexStats(): Future[IndexStatsResponse] = {
     for {
       narthexDatasets <- fetchNarthexDatasets()
-      (totalIndexed, hub3Counts) <- fetchHub3IndexCounts()
+      hub3 <- fetchHub3IndexCounts()
     } yield {
+      val totalIndexed = hub3.total
+      val hub3Counts = hub3.counts
+
       // Merge Hub3 counts into Narthex datasets
       val mergedDatasets = narthexDatasets.map { ds =>
         ds.copy(indexCount = hub3Counts.getOrElse(ds.spec, 0))

--- a/app/services/TrendTrackingService.scala
+++ b/app/services/TrendTrackingService.scala
@@ -575,41 +575,47 @@ object TrendTrackingService extends Logging {
     invalidRecords: Int,
     indexedRecords: Int
   ): Unit = {
-    if (sourceRecords == 0) {
-      logger.debug("Skipping event snapshot: sourceRecords is 0")
-      return
-    }
-
     val lastSnapshot = getLastSnapshot(trendsLog)
-    lastSnapshot.foreach { prev =>
-      if (prev.sourceRecords == sourceRecords &&
+
+    // Only skip when this is truly the pre-harvest state: no prior history at
+    // all AND the new counts are all zero. Legitimate depublications (dataset
+    // emptied after having content) must be recorded so the UI can show the
+    // drop. Likewise large drops >50% are no longer silently dropped; they are
+    // logged as a warning but still captured, so the UI reflects reality even
+    // when a partial harvest produced them.
+    val shouldSkip = lastSnapshot match {
+      case None =>
+        sourceRecords == 0 && validRecords == 0 && indexedRecords == 0
+      case Some(prev) =>
+        prev.sourceRecords == sourceRecords &&
           prev.acquiredRecords == acquiredRecords &&
           prev.deletedRecords == deletedRecords &&
           prev.validRecords == validRecords &&
           prev.invalidRecords == invalidRecords &&
-          prev.indexedRecords == indexedRecords) {
-        logger.debug("Skipping event snapshot: counts unchanged")
-        return
-      }
-
-      if (prev.sourceRecords > 0 && sourceRecords < prev.sourceRecords * 0.5) {
-        logger.warn(s"Skipping event snapshot: sourceRecords dropped from ${prev.sourceRecords} to $sourceRecords (>50% drop, likely partial harvest)")
-        return
-      }
+          prev.indexedRecords == indexedRecords
     }
 
-    val snapshot = TrendSnapshot(
-      timestamp = nowUtc,
-      snapshotType = event,
-      sourceRecords = sourceRecords,
-      acquiredRecords = acquiredRecords,
-      deletedRecords = deletedRecords,
-      validRecords = validRecords,
-      invalidRecords = invalidRecords,
-      indexedRecords = indexedRecords
-    )
-    appendSnapshot(trendsLog, snapshot)
-    logger.debug(s"Captured event snapshot ($event): source=$sourceRecords, valid=$validRecords, indexed=$indexedRecords")
+    if (shouldSkip) {
+      logger.debug(s"Skipping event snapshot for $event: no change or pre-harvest zero state")
+    } else {
+      lastSnapshot.foreach { prev =>
+        if (prev.sourceRecords > 0 && sourceRecords < prev.sourceRecords * 0.5) {
+          logger.warn(s"Large sourceRecords drop for $event: ${prev.sourceRecords} -> $sourceRecords (recording anyway — verify upstream isn't a partial harvest)")
+        }
+      }
+      val snapshot = TrendSnapshot(
+        timestamp = nowUtc,
+        snapshotType = event,
+        sourceRecords = sourceRecords,
+        acquiredRecords = acquiredRecords,
+        deletedRecords = deletedRecords,
+        validRecords = validRecords,
+        invalidRecords = invalidRecords,
+        indexedRecords = indexedRecords
+      )
+      appendSnapshot(trendsLog, snapshot)
+      logger.debug(s"Captured event snapshot ($event): source=$sourceRecords, valid=$validRecords, indexed=$indexedRecords")
+    }
   }
 
   /**

--- a/app/services/TrendTrackingService.scala
+++ b/app/services/TrendTrackingService.scala
@@ -747,7 +747,12 @@ object TrendTrackingService extends Logging {
     val current = summaries.last
     val cutoffDate = org.joda.time.LocalDate.parse(current.date).minusDays(daysAgo).toString("yyyy-MM-dd")
 
+    // Prefer a baseline on or before the cutoff; when the history is too
+    // short (e.g., 3 days of data, asking for 7d), fall back to the oldest
+    // non-current entry so the UI shows accurate growth within the window
+    // that's actually available instead of a misleading zero.
     val baseline = summaries.reverse.find(_.date <= cutoffDate)
+      .orElse(summaries.headOption.filterNot(_ == current))
 
     baseline match {
       case Some(base) =>

--- a/app/services/TrendTrackingService.scala
+++ b/app/services/TrendTrackingService.scala
@@ -195,6 +195,15 @@ object TrendTrackingService extends Logging {
   private val MAX_HISTORY_DAYS = 30
 
   /**
+   * Trend timestamps are always captured and compared in UTC so that the
+   * "which day does this snapshot belong to" question has a stable answer
+   * regardless of the JVM's default timezone. Without this, snapshots taken
+   * near midnight in a non-UTC zone would be assigned to the wrong day by
+   * aggregateDay's string-prefix filter.
+   */
+  private def nowUtc: DateTime = DateTime.now(org.joda.time.DateTimeZone.UTC)
+
+  /**
    * Capture a trend snapshot for a dataset.
    * Called after SAVE operations complete.
    *
@@ -218,7 +227,7 @@ object TrendTrackingService extends Logging {
     indexedRecords: Int
   ): Unit = {
     val snapshot = TrendSnapshot(
-      timestamp = DateTime.now(),
+      timestamp = nowUtc,
       snapshotType = snapshotType,
       sourceRecords = sourceRecords,
       acquiredRecords = acquiredRecords,
@@ -260,7 +269,7 @@ object TrendTrackingService extends Logging {
    * Get snapshots within a time window.
    */
   def getSnapshotsInWindow(trendsLog: File, hoursAgo: Int): List[TrendSnapshot] = {
-    val cutoff = DateTime.now().minusHours(hoursAgo)
+    val cutoff = nowUtc.minusHours(hoursAgo)
     readSnapshots(trendsLog).filter(_.timestamp.isAfter(cutoff))
   }
 
@@ -280,7 +289,7 @@ object TrendTrackingService extends Logging {
    * Compares most recent snapshot to the most recent snapshot before the window.
    */
   def calculateDeltaForWindow(snapshots: List[TrendSnapshot], hoursAgo: Int): TrendDelta = {
-    val cutoff = DateTime.now().minusHours(hoursAgo)
+    val cutoff = nowUtc.minusHours(hoursAgo)
     val sorted = snapshots.sortBy(_.timestamp.getMillis)
 
     val current = sorted.lastOption
@@ -340,7 +349,7 @@ object TrendTrackingService extends Logging {
   def cleanupOldSnapshots(trendsLog: File): Unit = {
     withFileLock(trendsLog) {
       val snapshots = readSnapshots(trendsLog)
-      val cutoff = DateTime.now().minusDays(MAX_HISTORY_DAYS)
+      val cutoff = nowUtc.minusDays(MAX_HISTORY_DAYS)
 
       val toKeep = snapshots.filter { s =>
         s.timestamp.isAfter(cutoff) || s.snapshotType == "daily"
@@ -438,7 +447,7 @@ object TrendTrackingService extends Logging {
     }
 
     val summary = TrendsSummaryFile(
-      generatedAt = DateTime.now(),
+      generatedAt = nowUtc,
       summaries = summaries
     )
 
@@ -480,7 +489,7 @@ object TrendTrackingService extends Logging {
     } match {
       case scala.util.Success(summary) =>
         // Check if summary is too old
-        val ageHours = (DateTime.now().getMillis - summary.generatedAt.getMillis) / (1000 * 60 * 60)
+        val ageHours = (nowUtc.getMillis - summary.generatedAt.getMillis) / (1000 * 60 * 60)
         if (ageHours > maxAgeHours) {
           logger.debug(s"Trends summary is stale (${ageHours}h old)")
           None
@@ -590,7 +599,7 @@ object TrendTrackingService extends Logging {
     }
 
     val snapshot = TrendSnapshot(
-      timestamp = DateTime.now(),
+      timestamp = nowUtc,
       snapshotType = event,
       sourceRecords = sourceRecords,
       acquiredRecords = acquiredRecords,
@@ -677,11 +686,11 @@ object TrendTrackingService extends Logging {
   def aggregateDay(trendsLog: File, dailyLog: File, date: String): Unit = {
     val allSnapshots = readSnapshots(trendsLog)
 
-    // Filter to snapshots whose ISO timestamp begins with the target date,
-    // then take the last one within that date so we ignore any snapshots
-    // taken after midnight on day+1.
+    // Filter to snapshots whose UTC date matches the target. Forcing UTC
+    // eliminates midnight-boundary bugs that arise when the capture timestamp
+    // was recorded in the JVM's default zone but `date` is a UTC calendar day.
     val daySnapshots = allSnapshots.filter { s =>
-      timeToString(s.timestamp).startsWith(date)
+      s.timestamp.withZone(org.joda.time.DateTimeZone.UTC).toString("yyyy-MM-dd") == date
     }
     val endOfDaySnapshot = daySnapshots.sortBy(_.timestamp.getMillis).lastOption
 
@@ -786,7 +795,7 @@ object TrendTrackingService extends Logging {
     val lastSnapshot = getLastSnapshot(trendsLog)
 
     // Get recent event snapshots (last 48h) for detailed 24h chart
-    val cutoff48h = DateTime.now().minusHours(48)
+    val cutoff48h = nowUtc.minusHours(48)
     val recentEvents = readSnapshots(trendsLog)
       .filter(s => s.timestamp.isAfter(cutoff48h) && s.snapshotType != "daily")
       .sortBy(_.timestamp.getMillis)
@@ -826,7 +835,7 @@ object TrendTrackingService extends Logging {
     }
 
     val summary = TrendsSummaryFile(
-      generatedAt = DateTime.now(),
+      generatedAt = nowUtc,
       summaries = summaries
     )
 

--- a/app/services/TrendTrackingService.scala
+++ b/app/services/TrendTrackingService.scala
@@ -534,17 +534,19 @@ object TrendTrackingService extends Logging {
       indexed = summaries.map(_.delta24h.indexed).sum
     )
 
-    // Categorize datasets by 24h delta
+    // Categorize datasets by 24h delta. Includes `valid` so datasets whose
+    // processed counts moved (without source/indexed movement) don't hide in
+    // the 'stable' bucket.
     val growing = summaries.filter(s =>
-      s.delta24h.source > 0 || s.delta24h.indexed > 0
-    ).sortBy(s => -(s.delta24h.source + s.delta24h.indexed))
+      s.delta24h.source > 0 || s.delta24h.indexed > 0 || s.delta24h.valid > 0
+    ).sortBy(s => -(s.delta24h.source + s.delta24h.indexed + s.delta24h.valid))
 
     val shrinking = summaries.filter(s =>
-      s.delta24h.source < 0 || s.delta24h.indexed < 0
-    ).sortBy(s => s.delta24h.source + s.delta24h.indexed)
+      s.delta24h.source < 0 || s.delta24h.indexed < 0 || s.delta24h.valid < 0
+    ).sortBy(s => s.delta24h.source + s.delta24h.indexed + s.delta24h.valid)
 
     val stable = summaries.filter(s =>
-      s.delta24h.source == 0 && s.delta24h.indexed == 0
+      s.delta24h.source == 0 && s.delta24h.indexed == 0 && s.delta24h.valid == 0
     ).sortBy(_.spec)
 
     OrganizationTrends(
@@ -838,7 +840,8 @@ object TrendTrackingService extends Logging {
         delta30d = calculateDeltaFromDailySummaries(dailySums, 30),
         history = dailySums.takeRight(MAX_HISTORY_DAYS).map { ds =>
           TrendSnapshot(
-            timestamp = DateTime.parse(ds.date + "T23:59:59.000Z"),
+            timestamp = org.joda.time.LocalDate.parse(ds.date)
+              .toDateTime(new org.joda.time.LocalTime(23, 59, 59, 999), org.joda.time.DateTimeZone.UTC),
             snapshotType = "daily",
             sourceRecords = ds.endOfDay.sourceRecords,
             acquiredRecords = ds.endOfDay.acquiredRecords,

--- a/app/services/TrendTrackingService.scala
+++ b/app/services/TrendTrackingService.scala
@@ -115,7 +115,11 @@ case class DatasetTrendSummary(
   currentIndexed: Int,
   delta24h: TrendDelta,
   delta7d: TrendDelta,
-  delta30d: TrendDelta
+  delta30d: TrendDelta,
+  // true when no daily summary exists yet and the summary was synthesized from
+  // the raw event log (so deltas are unreliable). UI renders "Initializing"
+  // instead of misleading zero deltas.
+  initializing: Option[Boolean] = None
 )
 
 object DatasetTrendSummary {
@@ -571,12 +575,47 @@ object TrendTrackingService extends Logging {
       return None
     }
 
-    Using(Source.fromFile(trendsLog)) { source =>
-      source.getLines()
-        .filter(_.nonEmpty)
-        .foldLeft(Option.empty[String])((_, line) => Some(line))
-        .flatMap(line => Try(Json.parse(line).as[TrendSnapshot]).toOption)
-    }.getOrElse(None)
+    // Tail-read the final line via RandomAccessFile so the cost is O(1) in
+    // file length. Per-SAVE captures used to stream the entire trends.jsonl
+    // which grew unbounded on busy datasets and could time out during the
+    // change-detection read, silently dropping new captures.
+    Try {
+      val raf = new java.io.RandomAccessFile(trendsLog, "r")
+      try {
+        val fileLength = raf.length()
+
+        // Walk back over trailing newline bytes to find the last byte of content.
+        var endOfContent = fileLength - 1
+        var done = false
+        while (!done && endOfContent >= 0) {
+          raf.seek(endOfContent)
+          val b = raf.readByte()
+          if (b == '\n' || b == '\r') endOfContent -= 1
+          else done = true
+        }
+
+        if (endOfContent < 0) None
+        else {
+          // Walk back to the byte just after the newline preceding the last line.
+          var startOfLastLine = endOfContent
+          var foundBoundary = false
+          while (!foundBoundary && startOfLastLine > 0) {
+            raf.seek(startOfLastLine - 1)
+            val b = raf.readByte()
+            if (b == '\n' || b == '\r') foundBoundary = true
+            else startOfLastLine -= 1
+          }
+
+          val length = (endOfContent - startOfLastLine + 1).toInt
+          val buf = new Array[Byte](length)
+          raf.seek(startOfLastLine)
+          raf.readFully(buf)
+          val line = new String(buf, "UTF-8").trim
+          if (line.isEmpty) None
+          else Try(Json.parse(line).as[TrendSnapshot]).toOption
+        }
+      } finally raf.close()
+    }.toOption.flatten
   }
 
   /**
@@ -813,7 +852,10 @@ object TrendTrackingService extends Logging {
         delta30d = calculateDeltaFromDailySummaries(dailySummaries, 30)
       ))
     } else {
-      getDatasetTrendSummary(trendsLog, spec)
+      // Fallback reads raw event log; deltas are best-effort when only 1-2
+      // snapshots exist. Flag as initializing so the UI can distinguish
+      // "genuinely flat" from "first aggregation hasn't run yet".
+      getDatasetTrendSummary(trendsLog, spec).map(_.copy(initializing = Some(true)))
     }
   }
 

--- a/app/services/TrendTrackingService.scala
+++ b/app/services/TrendTrackingService.scala
@@ -548,6 +548,34 @@ object TrendTrackingService extends Logging {
     logger.debug(s"Captured event snapshot ($event): source=$sourceRecords, valid=$validRecords, indexed=$indexedRecords")
   }
 
+  /**
+   * Like captureEventSnapshot but inherits indexedRecords from the previous snapshot.
+   * Use this at SAVE time because Hub3 indexing is async and the true indexed count
+   * is not yet known. The daily aggregation path (OrgContext.runDailyTrendAggregation)
+   * reconciles with Hub3 and writes the real indexed count.
+   */
+  def captureEventSnapshotCarryingIndexed(
+    trendsLog: File,
+    event: String,
+    sourceRecords: Int,
+    acquiredRecords: Int,
+    deletedRecords: Int,
+    validRecords: Int,
+    invalidRecords: Int
+  ): Unit = {
+    val carriedIndexed = getLastSnapshot(trendsLog).map(_.indexedRecords).getOrElse(0)
+    captureEventSnapshot(
+      trendsLog = trendsLog,
+      event = event,
+      sourceRecords = sourceRecords,
+      acquiredRecords = acquiredRecords,
+      deletedRecords = deletedRecords,
+      validRecords = validRecords,
+      invalidRecords = invalidRecords,
+      indexedRecords = carriedIndexed
+    )
+  }
+
   // === Task 3: Daily summary read/write ===
 
   def appendDailySummary(dailyLog: File, summary: DailySummary): Unit = {
@@ -592,43 +620,59 @@ object TrendTrackingService extends Logging {
   // === Task 4: Daily aggregation logic ===
 
   def aggregateDay(trendsLog: File, dailyLog: File, date: String): Unit = {
-    val lastSnapshot = getLastSnapshot(trendsLog)
-    if (lastSnapshot.isEmpty) {
-      logger.debug(s"No snapshots to aggregate for $date")
-      return
+    val allSnapshots = readSnapshots(trendsLog)
+
+    // Filter to snapshots whose ISO timestamp begins with the target date,
+    // then take the last one within that date so we ignore any snapshots
+    // taken after midnight on day+1.
+    val daySnapshots = allSnapshots.filter { s =>
+      timeToString(s.timestamp).startsWith(date)
     }
+    val endOfDaySnapshot = daySnapshots.sortBy(_.timestamp.getMillis).lastOption
 
-    val current = lastSnapshot.get
-    val endOfDay = EndOfDayCounts.fromSnapshot(current)
+    if (endOfDaySnapshot.isEmpty) {
+      // No snapshots on that date — carry forward the previous day's end-of-day
+      // counts so the chart has a continuous series. Zero delta by definition.
+      val previousSummary = getLastDailySummary(dailyLog)
+      previousSummary match {
+        case Some(prev) =>
+          val summary = DailySummary(
+            date = date,
+            endOfDay = prev.endOfDay,
+            delta = TrendDelta.zero,
+            events = 0
+          )
+          appendDailySummary(dailyLog, summary)
+          logger.info(s"Aggregated $date with carry-forward (no snapshots on that date): source=${prev.endOfDay.sourceRecords}")
+        case None =>
+          logger.debug(s"No snapshots or previous summary available for $date; skipping")
+      }
+    } else {
+      val endOfDay = EndOfDayCounts.fromSnapshot(endOfDaySnapshot.get)
+      val todayEvents = daySnapshots.size
 
-    // Count events for this specific date
-    val datePrefix = date
-    val todayEvents = readSnapshots(trendsLog).count { s =>
-      timeToString(s.timestamp).startsWith(datePrefix)
+      val previousSummary = getLastDailySummary(dailyLog)
+      val delta = previousSummary match {
+        case Some(prev) =>
+          TrendDelta(
+            source = endOfDay.sourceRecords - prev.endOfDay.sourceRecords,
+            valid = endOfDay.validRecords - prev.endOfDay.validRecords,
+            indexed = endOfDay.indexedRecords - prev.endOfDay.indexedRecords
+          )
+        case None =>
+          TrendDelta.zero
+      }
+
+      val summary = DailySummary(
+        date = date,
+        endOfDay = endOfDay,
+        delta = delta,
+        events = todayEvents
+      )
+
+      appendDailySummary(dailyLog, summary)
+      logger.info(s"Aggregated daily summary for $date: source=${endOfDay.sourceRecords}, delta=${delta.source}, events=$todayEvents")
     }
-
-    val previousSummary = getLastDailySummary(dailyLog)
-
-    val delta = previousSummary match {
-      case Some(prev) =>
-        TrendDelta(
-          source = endOfDay.sourceRecords - prev.endOfDay.sourceRecords,
-          valid = endOfDay.validRecords - prev.endOfDay.validRecords,
-          indexed = endOfDay.indexedRecords - prev.endOfDay.indexedRecords
-        )
-      case None =>
-        TrendDelta.zero
-    }
-
-    val summary = DailySummary(
-      date = date,
-      endOfDay = endOfDay,
-      delta = delta,
-      events = todayEvents
-    )
-
-    appendDailySummary(dailyLog, summary)
-    logger.info(s"Aggregated daily summary for $date: source=${endOfDay.sourceRecords}, delta=${delta.source}")
   }
 
   // === Task 5: Fix delta calculation ===

--- a/app/services/TrendTrackingService.scala
+++ b/app/services/TrendTrackingService.scala
@@ -338,19 +338,72 @@ object TrendTrackingService extends Logging {
    * and recent event snapshots.
    */
   def cleanupOldSnapshots(trendsLog: File): Unit = {
-    val snapshots = readSnapshots(trendsLog)
-    val cutoff = DateTime.now().minusDays(MAX_HISTORY_DAYS)
+    withFileLock(trendsLog) {
+      val snapshots = readSnapshots(trendsLog)
+      val cutoff = DateTime.now().minusDays(MAX_HISTORY_DAYS)
 
-    val toKeep = snapshots.filter { s =>
-      s.timestamp.isAfter(cutoff) || s.snapshotType == "daily"
-    }.sortBy(_.timestamp.getMillis).takeRight(MAX_HISTORY_DAYS * 2)  // Keep reasonable history
+      val toKeep = snapshots.filter { s =>
+        s.timestamp.isAfter(cutoff) || s.snapshotType == "daily"
+      }.sortBy(_.timestamp.getMillis).takeRight(MAX_HISTORY_DAYS * 2)  // Keep reasonable history
 
-    // Rewrite file with only kept snapshots
-    if (toKeep.size < snapshots.size) {
-      val tmpFile = new File(trendsLog.getParent, trendsLog.getName + ".tmp")
-      toKeep.foreach(s => appendSnapshot(tmpFile, s))
-      tmpFile.renameTo(trendsLog)
-      logger.info(s"Cleaned up trends file: ${snapshots.size} -> ${toKeep.size} snapshots")
+      // Rewrite file with only kept snapshots via ATOMIC_MOVE to avoid losing
+      // writes that land between read and rename. All appendSnapshot calls also
+      // acquire the same file lock, so the rewrite sees a consistent state.
+      if (toKeep.size < snapshots.size) {
+        val tmpFile = new File(trendsLog.getParent, trendsLog.getName + ".tmp")
+        // Build the tmp file directly (appendSnapshot here would recursively
+        // re-enter the lock — a no-op on re-entrant FileLock, but avoid relying
+        // on that).
+        val writer = appender(tmpFile)
+        try {
+          toKeep.foreach { s =>
+            writer.write(Json.stringify(Json.toJson(s)) + "\n")
+          }
+          writer.flush()
+        } finally {
+          writer.close()
+        }
+        java.nio.file.Files.move(
+          tmpFile.toPath,
+          trendsLog.toPath,
+          java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+          java.nio.file.StandardCopyOption.REPLACE_EXISTING
+        )
+        logger.info(s"Cleaned up trends file: ${snapshots.size} -> ${toKeep.size} snapshots")
+      }
+    }
+  }
+
+  /**
+   * Acquire an exclusive lock for a trends file while executing `body`.
+   *
+   * Uses a JVM-level ReentrantLock keyed by canonical path for intra-process
+   * mutual exclusion (FileChannel.lock is process-level; overlapping locks
+   * from threads in the same JVM throw OverlappingFileLockException).
+   *
+   * Layered on top is a FileChannel.lock on a sidecar .lock file so that
+   * separate Narthex processes (e.g., test suite + dev server sharing the
+   * same NarthexFiles dir) also serialize.
+   */
+  private val pathLocks = new java.util.concurrent.ConcurrentHashMap[String, java.util.concurrent.locks.ReentrantLock]()
+
+  private def withFileLock[A](trendsLog: File)(body: => A): A = {
+    val canonicalKey = trendsLog.getCanonicalPath
+    val jvmLock = pathLocks.computeIfAbsent(canonicalKey, _ => new java.util.concurrent.locks.ReentrantLock())
+    jvmLock.lock()
+    try {
+      val lockFile = new File(trendsLog.getParent, trendsLog.getName + ".lock")
+      val raf = new java.io.RandomAccessFile(lockFile, "rw")
+      val channel = raf.getChannel
+      val fileLock = channel.lock()
+      try body
+      finally {
+        fileLock.release()
+        channel.close()
+        raf.close()
+      }
+    } finally {
+      jvmLock.unlock()
     }
   }
 
@@ -358,13 +411,15 @@ object TrendTrackingService extends Logging {
    * Append a snapshot to the trends file.
    */
   private def appendSnapshot(trendsLog: File, snapshot: TrendSnapshot): Unit = {
-    val line = Json.stringify(Json.toJson(snapshot)) + "\n"
-    val writer = appender(trendsLog)
-    try {
-      writer.write(line)
-      writer.flush()
-    } finally {
-      writer.close()
+    withFileLock(trendsLog) {
+      val line = Json.stringify(Json.toJson(snapshot)) + "\n"
+      val writer = appender(trendsLog)
+      try {
+        writer.write(line)
+        writer.flush()
+      } finally {
+        writer.close()
+      }
     }
   }
 

--- a/app/services/TrendTrackingService.scala
+++ b/app/services/TrendTrackingService.scala
@@ -475,7 +475,7 @@ object TrendTrackingService extends Logging {
    * @param summaryFile The trends_summary.json file at org level
    * @param maxAgeHours Maximum age in hours before considering stale (default 25 hours)
    */
-  def readTrendsSummary(summaryFile: File, maxAgeHours: Int = 25): Option[TrendsSummaryFile] = {
+  def readTrendsSummary(summaryFile: File, datasetsDir: File, maxAgeHours: Int = 25): Option[TrendsSummaryFile] = {
     if (!summaryFile.exists()) {
       logger.debug("Trends summary file does not exist")
       return None
@@ -488,13 +488,31 @@ object TrendTrackingService extends Logging {
       }.get
     } match {
       case scala.util.Success(summary) =>
-        // Check if summary is too old
+        // Age check: a long-stale summary (aggregation failed or was off) is
+        // treated as missing so the fallback rebuild path runs.
         val ageHours = (nowUtc.getMillis - summary.generatedAt.getMillis) / (1000 * 60 * 60)
         if (ageHours > maxAgeHours) {
           logger.debug(s"Trends summary is stale (${ageHours}h old)")
           None
         } else {
-          Some(summary)
+          // Cross-check: if any per-dataset trends-daily.jsonl is newer than
+          // the summary, the summary doesn't reflect the latest aggregation
+          // and we should rebuild rather than serve yesterday's answer.
+          val newestDailyMtime = Option(datasetsDir.listFiles())
+            .getOrElse(Array.empty[File])
+            .flatMap { specDir =>
+              val dailyLog = new File(specDir, "trends-daily.jsonl")
+              if (dailyLog.exists()) Some(dailyLog.lastModified()) else None
+            }
+            .maxOption
+            .getOrElse(0L)
+
+          if (newestDailyMtime > summary.generatedAt.getMillis) {
+            logger.info("Trends summary is stale (per-dataset daily logs newer than summary)")
+            None
+          } else {
+            Some(summary)
+          }
         }
       case scala.util.Failure(e) =>
         logger.warn(s"Failed to read trends summary: ${e.getMessage}")

--- a/public/templates/trends.html
+++ b/public/templates/trends.html
@@ -138,14 +138,20 @@
                         </td>
                         <td>
                             <a href="#/?dataset={{ ds.spec }}">{{ ds.spec }}</a>
+                            <span ng-if="ds.initializing" class="label label-warning" style="margin-left: 6px;"
+                                  title="First daily aggregation has not run yet; deltas are unreliable until 00:30 UTC tomorrow.">
+                                Initializing
+                            </span>
                         </td>
                         <td class="text-right">{{ formatNumber(ds.currentSource) }}</td>
                         <td class="text-right">{{ formatNumber(ds.currentIndexed) }}</td>
-                        <td class="text-right" ng-class="getDeltaClass(getDelta(ds, 'source'))">
-                            {{ formatDelta(getDelta(ds, 'source')) }}
+                        <td class="text-right" ng-class="ds.initializing ? '' : getDeltaClass(getDelta(ds, 'source'))">
+                            <span ng-if="!ds.initializing">{{ formatDelta(getDelta(ds, 'source')) }}</span>
+                            <span ng-if="ds.initializing" class="text-muted">—</span>
                         </td>
-                        <td class="text-right" ng-class="getDeltaClass(getDelta(ds, 'indexed'))">
-                            {{ formatDelta(getDelta(ds, 'indexed')) }}
+                        <td class="text-right" ng-class="ds.initializing ? '' : getDeltaClass(getDelta(ds, 'indexed'))">
+                            <span ng-if="!ds.initializing">{{ formatDelta(getDelta(ds, 'indexed')) }}</span>
+                            <span ng-if="ds.initializing" class="text-muted">—</span>
                         </td>
                     </tr>
                     <tr ng-if="expandedSpec === ds.spec">

--- a/test/services/TrendTrackingServiceSpec.scala
+++ b/test/services/TrendTrackingServiceSpec.scala
@@ -419,6 +419,18 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     summaries.last.events shouldBe 0
   }
 
+  it should "fall back to oldest summary when no baseline at cutoff for 7d delta" in withTempDir { _ =>
+    val summaries = List(
+      DailySummary("2026-04-19", EndOfDayCounts(100, 100, 0, 90, 10, 80), TrendDelta.zero, 1),
+      DailySummary("2026-04-20", EndOfDayCounts(200, 200, 0, 180, 20, 170), TrendDelta.zero, 1),
+      DailySummary("2026-04-21", EndOfDayCounts(300, 300, 0, 280, 20, 260), TrendDelta.zero, 1)
+    )
+    val delta = TrendTrackingService.calculateDeltaFromDailySummaries(summaries, 7)
+    delta.source shouldBe 200
+    delta.valid shouldBe 190
+    delta.indexed shouldBe 180
+  }
+
   it should "assign a near-midnight UTC snapshot to that same UTC date" in withTempDir { tmpDir =>
     val trendsLog = new File(tmpDir, "trends.jsonl")
     val dailyLog = new File(tmpDir, "trends-daily.jsonl")

--- a/test/services/TrendTrackingServiceSpec.scala
+++ b/test/services/TrendTrackingServiceSpec.scala
@@ -87,14 +87,15 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     trendsLog.length() shouldBe sizeBefore
   }
 
-  it should "skip when sourceRecords drops more than 50%" in withTempDir { dir =>
+  it should "still capture a snapshot when sourceRecords drops more than 50%" in withTempDir { dir =>
+    // Intentional: we no longer hide >50% drops. Legitimate large deletions must
+    // be recorded so the UI can show the dataset shrinking.
     val trendsLog = new File(dir, "trends.jsonl")
     TrendTrackingService.captureEventSnapshot(trendsLog, "harvest", 1000, 1000, 0, 900, 100, 800)
 
     val sizeBefore = trendsLog.length()
-    // Try with 40% of original (>50% drop)
     TrendTrackingService.captureEventSnapshot(trendsLog, "harvest", 400, 400, 0, 360, 40, 320)
-    trendsLog.length() shouldBe sizeBefore
+    trendsLog.length() should be > sizeBefore
   }
 
   it should "write snapshot when counts change" in withTempDir { dir =>
@@ -451,6 +452,36 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     sums.size shouldBe 1
     sums.head.date shouldBe "2026-04-19"
     sums.head.endOfDay.sourceRecords shouldBe 100
+  }
+
+  "captureEventSnapshot guards" should "capture a zero-source snapshot when a prior snapshot exists (depublication)" in withTempDir { tmpDir =>
+    val trendsLog = new File(tmpDir, "trends.jsonl")
+    TrendTrackingService.captureEventSnapshot(
+      trendsLog, "save",
+      sourceRecords = 500, acquiredRecords = 500, deletedRecords = 0,
+      validRecords = 450, invalidRecords = 50, indexedRecords = 400
+    )
+    TrendTrackingService.captureEventSnapshot(
+      trendsLog, "save",
+      sourceRecords = 0, acquiredRecords = 0, deletedRecords = 500,
+      validRecords = 0, invalidRecords = 0, indexedRecords = 0
+    )
+    TrendTrackingService.readSnapshots(trendsLog).size shouldBe 2
+  }
+
+  it should "still capture a snapshot when source drops >50%" in withTempDir { tmpDir =>
+    val trendsLog = new File(tmpDir, "trends.jsonl")
+    TrendTrackingService.captureEventSnapshot(
+      trendsLog, "save",
+      sourceRecords = 1000, acquiredRecords = 1000, deletedRecords = 0,
+      validRecords = 900, invalidRecords = 100, indexedRecords = 800
+    )
+    TrendTrackingService.captureEventSnapshot(
+      trendsLog, "save",
+      sourceRecords = 300, acquiredRecords = 300, deletedRecords = 700,
+      validRecords = 270, invalidRecords = 30, indexedRecords = 800
+    )
+    TrendTrackingService.readSnapshots(trendsLog).size shouldBe 2
   }
 
   // === Task 5 fix: cleanup/append race ===

--- a/test/services/TrendTrackingServiceSpec.scala
+++ b/test/services/TrendTrackingServiceSpec.scala
@@ -418,4 +418,42 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     summaries.last.delta shouldBe TrendDelta.zero
     summaries.last.events shouldBe 0
   }
+
+  // === Task 5 fix: cleanup/append race ===
+
+  "cleanupOldSnapshots" should "not lose snapshots when concurrent appends happen" in withTempDir { tmpDir =>
+    val trendsLog = new File(tmpDir, "trends.jsonl")
+    // Seed 10 snapshots older than 30 days so cleanup will discard them
+    val oldTimestamp = DateTime.now().minusDays(60)
+    (1 to 10).foreach { i =>
+      val snap = TrendSnapshot(
+        timestamp = oldTimestamp.plusMinutes(i),
+        snapshotType = "event",
+        sourceRecords = 100 + i, acquiredRecords = 100 + i, deletedRecords = 0,
+        validRecords = 100 + i, invalidRecords = 0, indexedRecords = 100 + i
+      )
+      val w = services.FileHandling.appender(trendsLog)
+      try { w.write(Json.stringify(Json.toJson(snap)) + "\n") } finally { w.close() }
+    }
+
+    // Concurrent writers inject fresh snapshots while cleanup runs
+    val writerThreads = (1 to 10).map { n =>
+      new Thread(() => {
+        TrendTrackingService.captureEventSnapshot(
+          trendsLog, "save",
+          sourceRecords = 2000 + n, acquiredRecords = 2000 + n, deletedRecords = 0,
+          validRecords = 1800, invalidRecords = 200, indexedRecords = 1700
+        )
+      })
+    }
+    val cleaner = new Thread(() => TrendTrackingService.cleanupOldSnapshots(trendsLog))
+    writerThreads.foreach(_.start())
+    cleaner.start()
+    writerThreads.foreach(_.join())
+    cleaner.join()
+
+    val finalSnaps = TrendTrackingService.readSnapshots(trendsLog)
+    val concurrentCaptured = finalSnaps.map(_.sourceRecords).filter(_ >= 2001).toSet
+    concurrentCaptured.size shouldBe 10
+  }
 }

--- a/test/services/TrendTrackingServiceSpec.scala
+++ b/test/services/TrendTrackingServiceSpec.scala
@@ -281,16 +281,28 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     result.get.currentIndexed shouldBe 130
   }
 
-  it should "fall back to trends log when no daily data exists" in withTempDir { dir =>
+  it should "fall back to trends log when no daily data exists and mark as initializing" in withTempDir { dir =>
     val dailyLog = new File(dir, "trends-daily.jsonl")
     val trendsLog = new File(dir, "trends.jsonl")
 
-    // Write only to trends log
     TrendTrackingService.captureEventSnapshot(trendsLog, "harvest", 100, 100, 0, 90, 10, 80)
 
     val result = TrendTrackingService.getDatasetTrendSummaryFromDaily(dailyLog, trendsLog, "test-spec")
     result shouldBe defined
     result.get.currentSource shouldBe 100
+    result.get.initializing shouldBe Some(true)
+  }
+
+  it should "not mark as initializing when daily summaries exist" in withTempDir { dir =>
+    val dailyLog = new File(dir, "trends-daily.jsonl")
+    val trendsLog = new File(dir, "trends.jsonl")
+
+    TrendTrackingService.appendDailySummary(dailyLog,
+      DailySummary("2026-04-21", EndOfDayCounts(100, 100, 0, 90, 10, 80), TrendDelta.zero, 1))
+
+    val result = TrendTrackingService.getDatasetTrendSummaryFromDaily(dailyLog, trendsLog, "test-spec")
+    result shouldBe defined
+    result.get.initializing shouldBe None
   }
 
   "getDatasetTrendsFromDaily" should "build trends from daily summaries" in withTempDir { dir =>
@@ -467,6 +479,26 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
       validRecords = 0, invalidRecords = 0, indexedRecords = 0
     )
     TrendTrackingService.readSnapshots(trendsLog).size shouldBe 2
+  }
+
+  it should "tail-read the last snapshot from a large file" in withTempDir { tmpDir =>
+    val trendsLog = new File(tmpDir, "trends.jsonl")
+    // Pre-populate 5000 snapshots; insist getLastSnapshot returns the final one.
+    val w = services.FileHandling.appender(trendsLog)
+    try {
+      (1 to 5000).foreach { i =>
+        val snap = TrendSnapshot(
+          timestamp = new DateTime(2026, 1, 1, 0, 0, 0, org.joda.time.DateTimeZone.UTC).plusMinutes(i),
+          snapshotType = "save",
+          sourceRecords = i, acquiredRecords = i, deletedRecords = 0,
+          validRecords = i, invalidRecords = 0, indexedRecords = i
+        )
+        w.write(Json.stringify(Json.toJson(snap)) + "\n")
+      }
+    } finally { w.close() }
+
+    val last = TrendTrackingService.getLastSnapshot(trendsLog).get
+    last.sourceRecords shouldBe 5000
   }
 
   it should "still capture a snapshot when source drops >50%" in withTempDir { tmpDir =>

--- a/test/services/TrendTrackingServiceSpec.scala
+++ b/test/services/TrendTrackingServiceSpec.scala
@@ -169,8 +169,15 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     val trendsLog = new File(dir, "trends.jsonl")
     val dailyLog = new File(dir, "trends-daily.jsonl")
 
-    // Write a snapshot for today
-    TrendTrackingService.captureEventSnapshot(trendsLog, "harvest", 200, 200, 0, 180, 20, 160)
+    // Write a snapshot timestamped on 2026-02-18 so aggregateDay picks it up
+    val snap = TrendSnapshot(
+      timestamp = new DateTime(2026, 2, 18, 12, 0, 0),
+      snapshotType = "harvest",
+      sourceRecords = 200, acquiredRecords = 200, deletedRecords = 0,
+      validRecords = 180, invalidRecords = 20, indexedRecords = 160
+    )
+    val w1 = services.FileHandling.appender(trendsLog)
+    try { w1.write(Json.stringify(Json.toJson(snap)) + "\n") } finally { w1.close() }
 
     // Write a previous day summary
     TrendTrackingService.appendDailySummary(dailyLog,
@@ -193,7 +200,15 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     val trendsLog = new File(dir, "trends.jsonl")
     val dailyLog = new File(dir, "trends-daily.jsonl")
 
-    TrendTrackingService.captureEventSnapshot(trendsLog, "harvest", 100, 100, 0, 90, 10, 80)
+    val snap = TrendSnapshot(
+      timestamp = new DateTime(2026, 2, 18, 12, 0, 0),
+      snapshotType = "harvest",
+      sourceRecords = 100, acquiredRecords = 100, deletedRecords = 0,
+      validRecords = 90, invalidRecords = 10, indexedRecords = 80
+    )
+    val w = services.FileHandling.appender(trendsLog)
+    try { w.write(Json.stringify(Json.toJson(snap)) + "\n") } finally { w.close() }
+
     TrendTrackingService.aggregateDay(trendsLog, dailyLog, "2026-02-18")
 
     val summaries = TrendTrackingService.readDailySummaries(dailyLog)
@@ -306,5 +321,101 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     trends.spec shouldBe "test-spec"
     trends.current shouldBe defined
     trends.current.get.sourceRecords shouldBe 100
+  }
+
+  // === Task 1 fix: captureEventSnapshotCarryingIndexed ===
+
+  "captureEventSnapshotCarryingIndexed" should "carry previous indexedRecords forward" in withTempDir { tmpDir =>
+    val trendsLog = new File(tmpDir, "trends.jsonl")
+    // Seed a snapshot where Hub3 has 800 indexed
+    TrendTrackingService.captureEventSnapshot(
+      trendsLog, "save",
+      sourceRecords = 1000, acquiredRecords = 1000, deletedRecords = 0,
+      validRecords = 900, invalidRecords = 100, indexedRecords = 800
+    )
+    // New SAVE: valid climbs to 950 but Hub3 index not yet refreshed
+    TrendTrackingService.captureEventSnapshotCarryingIndexed(
+      trendsLog, "save",
+      sourceRecords = 1050, acquiredRecords = 1050, deletedRecords = 0,
+      validRecords = 950, invalidRecords = 100
+    )
+    val snaps = TrendTrackingService.readSnapshots(trendsLog)
+    snaps.size shouldBe 2
+    snaps.last.indexedRecords shouldBe 800
+    snaps.last.validRecords shouldBe 950
+  }
+
+  it should "use 0 indexed when no previous snapshot exists" in withTempDir { tmpDir =>
+    val trendsLog = new File(tmpDir, "trends.jsonl")
+    TrendTrackingService.captureEventSnapshotCarryingIndexed(
+      trendsLog, "save",
+      sourceRecords = 100, acquiredRecords = 100, deletedRecords = 0,
+      validRecords = 90, invalidRecords = 10
+    )
+    val snaps = TrendTrackingService.readSnapshots(trendsLog)
+    snaps.head.indexedRecords shouldBe 0
+  }
+
+  // === Task 2 fix: aggregateDay picks target-date snapshot ===
+
+  "aggregateDay" should "aggregate the last snapshot within the target date, not the global last" in withTempDir { tmpDir =>
+    val trendsLog = new File(tmpDir, "trends.jsonl")
+    val dailyLog = new File(tmpDir, "trends-daily.jsonl")
+
+    val yesterday = DateTime.now().minusDays(1).withTime(23, 50, 0, 0)
+    val today = DateTime.now().withTime(0, 5, 0, 0)
+
+    val yesterdaySnap = TrendSnapshot(
+      timestamp = yesterday,
+      snapshotType = "save",
+      sourceRecords = 1000, acquiredRecords = 1000, deletedRecords = 0,
+      validRecords = 900, invalidRecords = 100, indexedRecords = 850
+    )
+    val todaySnap = TrendSnapshot(
+      timestamp = today,
+      snapshotType = "save",
+      sourceRecords = 1500, acquiredRecords = 1500, deletedRecords = 0,
+      validRecords = 1400, invalidRecords = 100, indexedRecords = 850
+    )
+
+    val yesterdayDate = yesterday.toString("yyyy-MM-dd")
+
+    val w = services.FileHandling.appender(trendsLog)
+    try {
+      w.write(Json.stringify(Json.toJson(yesterdaySnap)) + "\n")
+      w.write(Json.stringify(Json.toJson(todaySnap)) + "\n")
+    } finally { w.close() }
+
+    TrendTrackingService.aggregateDay(trendsLog, dailyLog, yesterdayDate)
+
+    val summaries = TrendTrackingService.readDailySummaries(dailyLog)
+    summaries.size shouldBe 1
+    summaries.head.endOfDay.sourceRecords shouldBe 1000
+    summaries.head.endOfDay.validRecords shouldBe 900
+  }
+
+  it should "carry forward previous end-of-day when no snapshots exist on target date" in withTempDir { tmpDir =>
+    val trendsLog = new File(tmpDir, "trends.jsonl")
+    val dailyLog = new File(tmpDir, "trends-daily.jsonl")
+
+    val prev = DailySummary(
+      date = "2026-04-18",
+      endOfDay = EndOfDayCounts(
+        sourceRecords = 500, acquiredRecords = 500, deletedRecords = 0,
+        validRecords = 450, invalidRecords = 50, indexedRecords = 400
+      ),
+      delta = TrendDelta.zero,
+      events = 2
+    )
+    TrendTrackingService.appendDailySummary(dailyLog, prev)
+
+    TrendTrackingService.aggregateDay(trendsLog, dailyLog, "2026-04-19")
+
+    val summaries = TrendTrackingService.readDailySummaries(dailyLog)
+    summaries.size shouldBe 2
+    summaries.last.date shouldBe "2026-04-19"
+    summaries.last.endOfDay.sourceRecords shouldBe 500
+    summaries.last.delta shouldBe TrendDelta.zero
+    summaries.last.events shouldBe 0
   }
 }

--- a/test/services/TrendTrackingServiceSpec.scala
+++ b/test/services/TrendTrackingServiceSpec.scala
@@ -362,23 +362,23 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     val trendsLog = new File(tmpDir, "trends.jsonl")
     val dailyLog = new File(tmpDir, "trends-daily.jsonl")
 
-    val yesterday = DateTime.now().minusDays(1).withTime(23, 50, 0, 0)
-    val today = DateTime.now().withTime(0, 5, 0, 0)
+    // Explicit UTC timestamps so the test is deterministic regardless of JVM zone.
+    val utc = org.joda.time.DateTimeZone.UTC
+    val yesterdayTs = new DateTime(2026, 4, 20, 23, 50, 0, utc)
+    val todayTs = new DateTime(2026, 4, 21, 0, 5, 0, utc)
 
     val yesterdaySnap = TrendSnapshot(
-      timestamp = yesterday,
+      timestamp = yesterdayTs,
       snapshotType = "save",
       sourceRecords = 1000, acquiredRecords = 1000, deletedRecords = 0,
       validRecords = 900, invalidRecords = 100, indexedRecords = 850
     )
     val todaySnap = TrendSnapshot(
-      timestamp = today,
+      timestamp = todayTs,
       snapshotType = "save",
       sourceRecords = 1500, acquiredRecords = 1500, deletedRecords = 0,
       validRecords = 1400, invalidRecords = 100, indexedRecords = 850
     )
-
-    val yesterdayDate = yesterday.toString("yyyy-MM-dd")
 
     val w = services.FileHandling.appender(trendsLog)
     try {
@@ -386,7 +386,7 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
       w.write(Json.stringify(Json.toJson(todaySnap)) + "\n")
     } finally { w.close() }
 
-    TrendTrackingService.aggregateDay(trendsLog, dailyLog, yesterdayDate)
+    TrendTrackingService.aggregateDay(trendsLog, dailyLog, "2026-04-20")
 
     val summaries = TrendTrackingService.readDailySummaries(dailyLog)
     summaries.size shouldBe 1
@@ -417,6 +417,28 @@ class TrendTrackingServiceSpec extends AnyFlatSpec with should.Matchers {
     summaries.last.endOfDay.sourceRecords shouldBe 500
     summaries.last.delta shouldBe TrendDelta.zero
     summaries.last.events shouldBe 0
+  }
+
+  it should "assign a near-midnight UTC snapshot to that same UTC date" in withTempDir { tmpDir =>
+    val trendsLog = new File(tmpDir, "trends.jsonl")
+    val dailyLog = new File(tmpDir, "trends-daily.jsonl")
+
+    val nearMidnight = new DateTime(2026, 4, 19, 23, 55, 0, org.joda.time.DateTimeZone.UTC)
+    val snap = TrendSnapshot(
+      timestamp = nearMidnight,
+      snapshotType = "save",
+      sourceRecords = 100, acquiredRecords = 100, deletedRecords = 0,
+      validRecords = 90, invalidRecords = 10, indexedRecords = 80
+    )
+    val w = services.FileHandling.appender(trendsLog)
+    try { w.write(Json.stringify(Json.toJson(snap)) + "\n") } finally { w.close() }
+
+    TrendTrackingService.aggregateDay(trendsLog, dailyLog, "2026-04-19")
+
+    val sums = TrendTrackingService.readDailySummaries(dailyLog)
+    sums.size shouldBe 1
+    sums.head.date shouldBe "2026-04-19"
+    sums.head.endOfDay.sourceRecords shouldBe 100
   }
 
   // === Task 5 fix: cleanup/append race ===

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.8.7.18"
+ThisBuild / version := "0.8.7.19"


### PR DESCRIPTION
## Summary

Nine fixes addressing review findings that caused the trends UI to show wrong data and miss movement. Targets the remaining 15 issues not yet on main (2 blockers — #1 SAVE indexed count, #5 aggregateDay date filter — already shipped via 361016d4 on main).

Plan: `docs/plans/2026-04-21-trends-fixes-plan.md`.

### Commits / findings

| Commit | Addresses | Severity |
|--------|-----------|----------|
| fc376dea — skip aggregation when Hub3 unreachable | #2 | BLOCKER |
| 8705a8fa — bootstrap aggregation on startup | #3 | HIGH |
| 514e7a5d — JVM + file lock on append/cleanup | #6 | HIGH |
| 5b31f96b — UTC canonicalization | #7 | HIGH |
| 663764d5 — delta7d/30d oldest-baseline fallback | #4 | HIGH |
| 84f86363 — record depublications + >50% drops | #8, #9, #17 | MEDIUM/LOW |
| 8a2d2658 — summary cache mtime cross-check | #10 | MEDIUM |
| 05569a8d — totalDatasets + UTC + valid-delta classification | #11, #13, #16 | MEDIUM/LOW |
| 27af416f — O(1) getLastSnapshot + initializing UI flag | #12, #14 | MEDIUM/LOW |

Finding #15 (24h chart render threshold) already handled by existing fallback to dailySummaries.

### Notable behaviour changes

- **IndexStatsService.fetchHub3IndexCounts** signature: `Future[(Long, Map[String, Int])]` → `Future[Hub3IndexCounts]`. All callers updated.
- **DatasetTrendSummary** gains optional `initializing: Option[Boolean]`. JSON serializes as omitted when None.
- **TriggerTrendSnapshot** returns HTTP 503 instead of silently recording zeros when Hub3 is unreachable.
- **readTrendsSummary** signature: added `datasetsDir: File` parameter for mtime cross-check.

### Recovery after deploy

After restart, two paths reconcile historical noise:

1. **Automatic**: bootstrap aggregator runs 10s after startup if `trends_summary.json` is missing. Scheduled 00:30 UTC daily aggregation continues.
2. **Manual**: `POST /narthex/app/trends/snapshot` forces immediate capture + aggregation for every dataset using real Hub3 counts.

Pre-existing polluted `trends-daily.jsonl` entries stay but age out via 30-day retention. For clean slate: `rm` per-dataset `trends-daily.jsonl` + `trends_summary.json`, then hit the trigger endpoint.

## Test plan

- [x] `sbt test` — 83/83 pass (was 76 before; 7 new regression tests in TrendTrackingServiceSpec)
- [x] `make compile` clean
- [ ] Deploy to staging, hit `POST /narthex/app/trends/snapshot`, refresh `/narthex/#/trends`
- [ ] Verify growing/shrinking tabs populated (not all in stable)
- [ ] Verify 24h SAVE on a dataset does NOT cause indexed count to jump by valid delta
- [ ] Verify cache invalidation: touch a `trends-daily.jsonl` mtime, reload `/narthex/#/trends`, see fallback path execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)