### PR TITLE
fix(sip): rewrite stale facts in default-mapping XML (Planio #3117)

### DIFF
--- a/app/dataset/SipFactory.scala
+++ b/app/dataset/SipFactory.scala
@@ -19,6 +19,7 @@ import java.io.{File, FileInputStream, FileOutputStream}
 import java.util.zip.{GZIPOutputStream, ZipEntry, ZipOutputStream}
 
 import dataset.SipRepo.FACTS_FILE
+import dataset.Sip
 import java.util.HashMap
 import org.apache.commons.io.{FileUtils, IOUtils}
 import play.api.Logger
@@ -227,13 +228,22 @@ class SipPrefixRepo(home: File, rdfBaseUrl: String, ws: WSClient, orgId: String)
         copyIn(recordDefinition)
         copyIn(validation)
 
-        // Include mapping if provided (e.g., from default mappings)
+        // Include mapping if provided (e.g., from default mappings). Rewrite
+        // the `<facts>` block from the target dataset's facts so the template's
+        // stale spec / empty dataProviderURL don't leak into the new SIP.
         customMappingXml.foreach { mappingXml =>
           val mappingFileName = s"mapping_$prefix.xml"
           logger.info(s"Including default mapping in new SIP: $mappingFileName")
           zos.putNextEntry(new ZipEntry(mappingFileName))
-          val xmlBytes = mappingXml.getBytes("UTF-8")
-          zos.write(xmlBytes)
+          val bytesOpt = scala.util.Try(Sip.loadRecDefTree(recordDefinition)).toOption.flatMap { tree =>
+            Sip.rewriteFactsInMappingXml(mappingXml, tree, toMap(facts))
+          }
+          bytesOpt match {
+            case Some(bytes) => zos.write(bytes)
+            case None =>
+              logger.warn(s"Unable to rewrite facts for $mappingFileName; writing verbatim")
+              zos.write(mappingXml.getBytes("UTF-8"))
+          }
           zos.closeEntry()
         }
 

--- a/app/dataset/SipRepo.scala
+++ b/app/dataset/SipRepo.scala
@@ -151,6 +151,68 @@ object Sip {
 
   def apply(datasetName: String, rdfBaseUrl: String, zipFile: File) = new Sip(datasetName, rdfBaseUrl, zipFile)
 
+  private val logger = Logger(getClass)
+
+  /**
+   * Load a RecDefTree from an on-disk record-definition XML file.
+   *
+   * Default-mapping XML is imported verbatim from DefaultMappingRepo templates. The
+   * templates have a `<facts>` block carrying stale values (e.g. `spec` = template
+   * source dataset, `dataProviderURL` = empty). `rewriteFactsInMappingXml` lets
+   * callers re-parse the XML, overwrite facts from the target dataset's
+   * SipGenerationFacts, and re-serialize before the mapping is placed in the SIP.
+   */
+  def loadRecDefTree(recordDefinition: File): RecDefTree = {
+    val in = new FileInputStream(recordDefinition)
+    try RecDefTree.create(RecDef.read(in))
+    finally in.close()
+  }
+
+  /**
+   * Re-parse a customMappingXml string, overwrite its `<facts>` entries from
+   * `factsMap`, and serialize back. Returns None if the mapping cannot be
+   * parsed against the given RecDefTree (caller should fall back to verbatim
+   * write + log a warning).
+   */
+  def rewriteFactsInMappingXml(
+    customXml: String,
+    recDefTree: RecDefTree,
+    factsMap: java.util.Map[String, String]
+  ): Option[Array[Byte]] = {
+    Try {
+      val in = new ByteArrayInputStream(customXml.getBytes("UTF-8"))
+      try {
+        val recMapping = RecMapping.read(in, recDefTree)
+        factsMap.entrySet().asScala.foreach { e =>
+          recMapping.setFact(e.getKey, e.getValue)
+        }
+        val baos = new ByteArrayOutputStream()
+        RecMapping.write(baos, recMapping)
+        baos.toByteArray
+      } finally in.close()
+    }.toOption
+  }
+
+  /**
+   * Fact map without `baseUrl` / `schemaVersions`. Use when no SipPrefixRepo
+   * is available. Covers the fields the mapping Groovy code actually reads
+   * (spec, orgId, provider, dataProvider, dataProviderURL, etc.).
+   */
+  def factsToMap(facts: SipGenerationFacts): java.util.HashMap[String, String] = {
+    val map = new java.util.HashMap[String, String]()
+    map.put("spec", facts.spec)
+    map.put("name", facts.name)
+    map.put("provider", facts.provider)
+    map.put("dataProvider", facts.dataProvider)
+    map.put("dataProviderURL", facts.dataProviderURL)
+    map.put("language", facts.language)
+    map.put("rights", facts.rights)
+    map.put("type", facts.edmType)
+    map.put("dataType", facts.dataType)
+    map.put("orgId", facts.orgId)
+    map
+  }
+
   val XMLNS = "http://www.w3.org/2000/xmlns/"
   val RDF_ROOT_TAG: String = "RDF"
   val RDF_RECORD_TAG: String = "Description"
@@ -444,10 +506,19 @@ class Sip(val dsInfoSpec: String, rdfBaseUrl: String, val file: File) {
 
               customMappingXml match {
                 case Some(customXml) =>
-                  // Use custom mapping XML (e.g., from default mappings or DatasetMappingRepo)
+                  // Use custom mapping XML (e.g., from default mappings or
+                  // DatasetMappingRepo). Rewrite the `<facts>` block so the
+                  // target dataset's spec, orgId, dataProviderURL etc.
+                  // replace stale values copied from the template.
                   logger.debug(s"Using custom mapping XML for ${sipMapping.fileName}")
-                  val xmlBytes = customXml.getBytes("UTF-8")
-                  zos.write(xmlBytes)
+                  val factsMap = sipPrefixRepoOpt.map(_.toMap(facts)).getOrElse(Sip.factsToMap(facts))
+                  Sip.rewriteFactsInMappingXml(customXml, sipMapping.recDefTree, factsMap) match {
+                    case Some(bytes) =>
+                      zos.write(bytes)
+                    case None =>
+                      logger.warn(s"Could not parse customMappingXml for ${sipMapping.fileName}; writing verbatim (facts may be stale)")
+                      zos.write(customXml.getBytes("UTF-8"))
+                  }
 
                 case None =>
                   // if there is a new schema version, set it
@@ -470,7 +541,21 @@ class Sip(val dsInfoSpec: String, rdfBaseUrl: String, val file: File) {
                 case Some(customXml) =>
                   logger.info(s"sipMappingOpt is None, using custom mapping XML for ${entry.getName}")
                   zos.putNextEntry(new ZipEntry(entry.getName))
-                  zos.write(customXml.getBytes("UTF-8"))
+                  // Best-effort fact rewrite: we need a RecDefTree, which only
+                  // the prefix repo can supply here. Without it, write
+                  // verbatim (unchanged from prior behaviour).
+                  val bytesOpt = sipPrefixRepoOpt.flatMap { prefixRepo =>
+                    Try(Sip.loadRecDefTree(prefixRepo.recordDefinition)).toOption.flatMap { tree =>
+                      Sip.rewriteFactsInMappingXml(customXml, tree, prefixRepo.toMap(facts))
+                    }
+                  }
+                  bytesOpt match {
+                    case Some(bytes) =>
+                      zos.write(bytes)
+                    case None =>
+                      logger.warn(s"Unable to rewrite facts in customMappingXml (no prefix repo or parse failed); writing verbatim")
+                      zos.write(customXml.getBytes("UTF-8"))
+                  }
                   zos.closeEntry()
                   mappingWritten = true
                 case None =>
@@ -534,7 +619,19 @@ class Sip(val dsInfoSpec: String, rdfBaseUrl: String, val file: File) {
           val mappingFileName = s"mapping_$prefix.xml"
           logger.info(s"Adding default mapping to SIP: $mappingFileName")
           zos.putNextEntry(new ZipEntry(mappingFileName))
-          zos.write(mappingXml.getBytes("UTF-8"))
+          // Best-effort fact rewrite: requires a RecDefTree, which we obtain
+          // from the prefix repo's record definition.
+          val bytesOpt = sipPrefixRepoOpt.flatMap { prefixRepo =>
+            Try(Sip.loadRecDefTree(prefixRepo.recordDefinition)).toOption.flatMap { tree =>
+              Sip.rewriteFactsInMappingXml(mappingXml, tree, prefixRepo.toMap(facts))
+            }
+          }
+          bytesOpt match {
+            case Some(bytes) => zos.write(bytes)
+            case None =>
+              logger.warn(s"Unable to rewrite facts for $mappingFileName (no prefix repo or parse failed); writing verbatim")
+              zos.write(mappingXml.getBytes("UTF-8"))
+          }
           zos.closeEntry()
         }
       }

--- a/test/dataset/SipRepoFactsRewriteSpec.scala
+++ b/test/dataset/SipRepoFactsRewriteSpec.scala
@@ -1,0 +1,125 @@
+package dataset
+
+import java.io.{ByteArrayInputStream, File}
+
+import dataset.SipFactory.SipGenerationFacts
+import eu.delving.metadata.{RecDefTree, RecMapping}
+import org.scalatest.flatspec._
+import org.scalatest.matchers._
+
+/**
+ * Regression tests for Planio #3117 / default-mapping facts propagation.
+ *
+ * The bug: mapping XML imported from DefaultMappingRepo templates carried the
+ * template-source dataset's spec and an empty dataProviderURL into every new
+ * dataset's SIP. The fix rewrites the `<facts>` block from the target
+ * dataset's SipGenerationFacts before the mapping goes into the SIP zip.
+ */
+class SipRepoFactsRewriteSpec extends AnyFlatSpec with should.Matchers {
+
+  private def recDefTree(): RecDefTree = {
+    val recDefFile = new File(getClass.getResource("/edm/factory/edm/edm_5.2.3_record-definition.xml").getFile)
+    Sip.loadRecDefTree(recDefFile)
+  }
+
+  private def templateXml(templateSpec: String, emptyProviderUrl: Boolean = true): String =
+    s"""<rec-mapping prefix="edm" schemaVersion="5.2.3" locked="true">
+       |  <facts>
+       |    <entry>
+       |      <string>spec</string>
+       |      <string>$templateSpec</string>
+       |    </entry>
+       |    <entry>
+       |      <string>orgId</string>
+       |      <string>orig-org</string>
+       |    </entry>
+       |    <entry>
+       |      <string>dataProviderURL</string>
+       |      <string>${if (emptyProviderUrl) "" else "http://old.example.org"}</string>
+       |    </entry>
+       |    <entry>
+       |      <string>name</string>
+       |      <string>Template Name</string>
+       |    </entry>
+       |  </facts>
+       |  <functions/>
+       |  <node-mappings/>
+       |</rec-mapping>
+       |""".stripMargin
+
+  private def targetFacts: SipGenerationFacts = SipGenerationFacts(
+    spec = "enb-406-bidprentje",
+    prefix = "edm",
+    name = "Bidprentjes ENB 406",
+    provider = "Erfgoed Brabant",
+    dataProvider = "Heemkundekring Op 't Goede Spoor",
+    dataProviderURL = "https://www.goedespoorwaspik.nl/",
+    language = "NL",
+    rights = "http://rightsstatements.org/vocab/InC/1.0/",
+    edmType = "IMAGE",
+    dataType = "",
+    orgId = "brabantcloud"
+  )
+
+  private def parseFacts(bytes: Array[Byte]): Map[String, String] = {
+    val tree = recDefTree()
+    val in = new ByteArrayInputStream(bytes)
+    try {
+      val mapping = RecMapping.read(in, tree)
+      import scala.jdk.CollectionConverters._
+      mapping.getFacts.asScala.toMap
+    } finally in.close()
+  }
+
+  "Sip.rewriteFactsInMappingXml" should "replace the template spec with the target spec" in {
+    val bytesOpt = Sip.rewriteFactsInMappingXml(
+      templateXml("enb-test-bidprentje"),
+      recDefTree(),
+      Sip.factsToMap(targetFacts)
+    )
+    bytesOpt shouldBe defined
+    val facts = parseFacts(bytesOpt.get)
+    facts.get("spec") shouldBe Some("enb-406-bidprentje")
+  }
+
+  it should "populate dataProviderURL when the template has an empty value" in {
+    val bytesOpt = Sip.rewriteFactsInMappingXml(
+      templateXml("enb-test-bidprentje", emptyProviderUrl = true),
+      recDefTree(),
+      Sip.factsToMap(targetFacts)
+    )
+    bytesOpt shouldBe defined
+    val facts = parseFacts(bytesOpt.get)
+    facts.get("dataProviderURL") shouldBe Some("https://www.goedespoorwaspik.nl/")
+  }
+
+  it should "overwrite a stale dataProviderURL" in {
+    val bytesOpt = Sip.rewriteFactsInMappingXml(
+      templateXml("enb-test-bidprentje", emptyProviderUrl = false),
+      recDefTree(),
+      Sip.factsToMap(targetFacts)
+    )
+    bytesOpt shouldBe defined
+    val facts = parseFacts(bytesOpt.get)
+    facts.get("dataProviderURL") shouldBe Some("https://www.goedespoorwaspik.nl/")
+  }
+
+  it should "overwrite orgId as well" in {
+    val bytesOpt = Sip.rewriteFactsInMappingXml(
+      templateXml("enb-test-bidprentje"),
+      recDefTree(),
+      Sip.factsToMap(targetFacts)
+    )
+    val facts = parseFacts(bytesOpt.get)
+    facts.get("orgId") shouldBe Some("brabantcloud")
+  }
+
+  it should "return None when the customMappingXml can't be parsed" in {
+    val result = Sip.rewriteFactsInMappingXml(
+      "<not-rec-mapping/>",
+      recDefTree(),
+      Sip.factsToMap(targetFacts)
+    )
+    result shouldBe None
+  }
+}


### PR DESCRIPTION
## Summary

Fixes [Planio #3117](https://delving.planio.com/issues/3117) — Instant Website detail pages for `enb-406-bidprentje` / `enb-406-objecten` don't open because hubIds contain `enb-test-bidprentje` (the template source) instead of the actual dataset spec. Same root cause causes the UI-entered "Data Provider URL" to not reach the generated RDF.

### Root cause

Default-mapping XML templates under \`NarthexFiles/<org>/default-mappings/\` carry a \`<facts>\` block copied from the template's source dataset:
- \`spec\` = template source (\`enb-test-bidprentje\`)
- \`dataProviderURL\` = empty string

Narthex's four \`customMappingXml\` write sites copied this XML verbatim into the generated SIP. The Groovy mapping code reads facts by name (e.g. \`_facts.dataProviderURL\`) → wrong / empty values downstream.

The normal path (no \`customMappingXml\`) already calls \`RecMapping.setFact\` for each entry of \`SipPrefixRepo.toMap(facts)\` before \`RecMapping.write\` (\`SipRepo.scala\` unchanged block). The custom paths just skipped that step.

### Fix

All four custom paths now parse the customMappingXml into a \`RecMapping\` via \`RecMapping.read(in, recDefTree)\`, overwrite facts from the target dataset's \`SipGenerationFacts\`, then serialize via \`RecMapping.write\`. On parse failure, log a warning and fall back to verbatim write (unchanged from prior behaviour — strictly not worse).

New helpers in \`Sip\` companion:
- \`loadRecDefTree(File)\` — mirrors existing zip-based \`recDefTree(String)\`
- \`rewriteFactsInMappingXml(xml, tree, factsMap)\` — returns Option[Array[Byte]]
- \`factsToMap(facts)\` — SipGenerationFacts → Map without needing a SipPrefixRepo

### Scope

Write sites patched:
1. \`SipRepo.scala\` existing-parseable-mapping branch
2. \`SipRepo.scala\` unparseable-mapping branch (best-effort via prefix repo's recordDefinition)
3. \`SipRepo.scala\` no-existing-mapping fallback
4. \`SipFactory.initiateSipZip\` (brand-new SIP)

### Recovery for pre-fix datasets

For each dataset imported via Dataset Discovery + Default Mappings before this fix:

1. \`start generating sip\` (regenerates SIP with rewritten facts)
2. \`start processing\` (reprocesses with correct hubIds)
3. \`start saving\` (re-indexes into Hub3)

Old hubIds remain in Hub3 until operator purge — out of scope for this PR.

## Test plan

- [x] \`sbt test\` — 88/88 pass (5 new regression tests in SipRepoFactsRewriteSpec)
- [x] \`make compile\` clean
- [ ] Deploy to staging
- [ ] Import a test dataset via Dataset Discovery + Default Mappings
- [ ] Set Data Provider URL in UI, trigger SIP generation
- [ ] \`unzip -p <spec>/sips/<latest>.sip.zip mapping_edm.xml | grep -A1 "spec\\|dataProviderURL"\` → target spec + UI-entered URL
- [ ] Inspect generated hubId in Hub3 index → matches \`brabantcloud_<spec>_<localId>/graph\`
- [ ] Regenerate + reprocess \`enb-406-bidprentje\` / \`enb-406-objecten\`, verify Instant Website detail pages open

🤖 Generated with [Claude Code](https://claude.com/claude-code)